### PR TITLE
Consistency in underscores

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -8,24 +8,24 @@ This specification contains a collection of RESTful APIs used to specify the dig
 
 ## Table of Contents
 
-* [register-vehicle](#register-vehicle)
-* [remove-vehicle](#remove-vehicle)
-* [service-vehicle](#service-vehicle)
-* [report-maintenance](#report-maintenance)
-* [pilot-movement-plan](#pilot-movement-plan)
-* [activate-movement-plan](#activate-movement-plan)
-* [close-movement-plan](#close-movement-plan)
-* [update-trip-data](#update-trip-data)
-* [check-parking](#check-parking)
-* [get-parking-info](#get-parking-info)
-* [service-areas](#service-areas)
+* [register_vehicle](#register_vehicle)
+* [remove_vehicle](#remove_vehicle)
+* [service_vehicle](#service_vehicle)
+* [report_maintenance](#report_maintenance)
+* [pilot_movement_plan](#pilot_movement_plan)
+* [activate_movement_plan](#activate_movement_plan)
+* [close_movement_plan](#close_movement_plan)
+* [update_trip_data](#update_trip_data)
+* [check_parking](#check_parking)
+* [get_parking_info](#get_parking_info)
+* [service_areas](#service_areas)
 * [Enum definitions](#enum-definitions)
 
-## register-vehicle
+## register_vehicle
 
 The Vehicle Registration API is required in order to register a vehicle for use in the system. The API will require a valid `provider_id` and `api_key`.
 
-Endpoint: `/register-vehicle`  
+Endpoint: `/register_vehicle`  
 Method: `POST`  
 Body:
 
@@ -46,11 +46,11 @@ Response:
 | ----- | -------- | ----------------- | ----- |
 | `vehicle_id` | UUID |  | Used for accessing vehicle operations API's |
 
-## remove-vehicle
+## remove_vehicle
 
-The remove-vehicle API is used to deregister a vehicle from the fleet.
+The remove_vehicle API is used to deregister a vehicle from the fleet.
 
-Endpoint: `/remove-vehicle`  
+Endpoint: `/remove_vehicle`  
 Method: `POST`  
 Body:
 
@@ -65,11 +65,11 @@ Response:
 | ----- | -------- | ----------------- | ----- |
 | `message` | Enum |  | See [Message](#message) Enum |
 
-## service-vehicle
+## service_vehicle
 
 This API is used by providers when a vehicle is either removed or returned to service.
 
-Endpoint: `/service-vehicle`  
+Endpoint: `/service_vehicle`  
 Method: `POST`  
 Body:
 
@@ -87,11 +87,11 @@ Response:
 | ----- | -------- | ----------------- | ----- |
 | `message` | Enum |  | See [Message](#message) Enum |
 
-## report-maintenance
+## report_maintenance
 
 Used to report maintenance events.
 
-Endpoint: `/report-maintenance`  
+Endpoint: `/report_maintenance`  
 Method: `POST`  
 Body:
 
@@ -108,11 +108,11 @@ Response:
 | ----- | -------- | ----------------- | ----- |
 | `message` | Enum |  | See [Message](#message) Enum |
 
-## pilot-movement-plan
+## pilot_movement_plan
 
-The pilot-movement-plan API is used for initiating a trip request from a human piloted vehicle. It will be required for ALL trips at the time of departure. The API will acknowledge the request with a response containing a permission to proceed and a unique Trip Identifier.
+The pilot_movement_plan API is used for initiating a trip request from a human piloted vehicle. It will be required for ALL trips at the time of departure. The API will acknowledge the request with a response containing a permission to proceed and a unique Trip Identifier.
 
-Endpoint: `/pilot-movement-plan`  
+Endpoint: `/pilot_movement_plan`  
 Method: `POST`  
 Body:
 
@@ -130,17 +130,17 @@ Response:
 | ----- | -------- | ----------------- | ----- |
 | `trip_id` | UUID |  | a unique ID for each trip | 
 
-## activate-movement-plan
+## activate_movement_plan
 
 This API will take an initialized API using `trip_id` as a reference and will activate it, meaning that the trip is in motion.  This API can also be used to re-activate a deactivated movement plan.
 
-Endpoint: `/activate-movement-plan`  
+Endpoint: `/activate_movement_plan`  
 Method: `POST`  
 Body:
 
 | Field | Type     | Required/Optional | Other |
 | ----- | -------- | ----------------- | ----- |
-| `trip_id` | UUID |  | Issued by pilot-movement-plan API | 
+| `trip_id` | UUID |  | Issued by pilot_movement_plan API | 
 
 Response:
 
@@ -148,11 +148,11 @@ Response:
 | ----- | -------- | ----------------- | ----- |
 | `message` | Enum |  | See [Message](#message) Enum |
 
-## close-movement-plan 
+## close_movement_plan 
 
 This API will close a Movement Plan for a given `trip_id`. The response includes a warning whether parking is enforced for the given GPS Position.
 
-Endpoint: `/close-movement-plan`  
+Endpoint: `/close_movement_plan`  
 Method: `POST`  
 Body:
 
@@ -168,11 +168,11 @@ Response:
 | ----- | -------- | ----- |
 | `message` | Enum | See [Message](#message) Enum |
 
-## update-trip-data
+## update_trip_data
 
 A trip represents a route taken by a provider's customer.   Trip data will be reported to the API every 5 seconds while the vehicle is in motion.   
 
-Endpoint: `/update-trip-data`  
+Endpoint: `/update_trip_data`  
 Method: `POST`  
 Body:
 
@@ -188,11 +188,11 @@ Response:
 | ---- | --- | --- |
 | `message` | Enum | See [Message](#message) Enum | 
 
-## check-parking
+## check_parking
 
 This API is used to determine whether parking is regulated for a given destination.
 
-Endpoint: `/check-parking`  
+Endpoint: `/check_parking`  
 Method: `POST`  
 Body:
 
@@ -207,11 +207,11 @@ Response:
 | ----- | -------- | ----------------- | ----- |
 | `message` | Enum | | See [Message](#message) Enum | 
 
-## get-parking-info
+## get_parking_info
 
 This API returns a list of approved parking spaces based on post parameters.
 
-Endpoint: `/get-parking-info`  
+Endpoint: `/get_parking_info`  
 Method: `POST`  
 Body: 
 
@@ -230,11 +230,11 @@ Reponse:
 | `price` | Decimal |  | Price (Amount) |
 | `currency` | Enum |  | (`USD`, `CAD`) |
 
-## service-areas
+## service_areas
 
 Gets the list of service areas available to the provider.
 
-Endpoint: `/service-areas`  
+Endpoint: `/service_areas`  
 Method: `GET`  
 Body: 
 

--- a/agency/README.md
+++ b/agency/README.md
@@ -3,22 +3,19 @@
 This specification contains a collection of RESTful APIs used to specify the digital relationship between *mobility as a service* providers and the agencies that regulate them.
 
 * Authors: LADOT
-* Date: 23 May 2018
+* Date: 10 Aug 2018
 * Version: ALPHA
 
 ## Table of Contents
 
 * [register_vehicle](#register_vehicle)
 * [deregister_vehicle](#deregister_vehicle)
-* [service_vehicle](#service_vehicle)
-* [report_maintenance](#report_maintenance)
-* [pilot_movement_plan](#pilot_movement_plan)
-* [activate_movement_plan](#activate_movement_plan)
-* [close_movement_plan](#close_movement_plan)
-* [update_trip_data](#update_trip_data)
-* [check_parking](#check_parking)
-* [get_parking_info](#get_parking_info)
+* [update_vehicle_status](#update_vehicle_status)
+* [start_trip](#start_trip)
+* [end_trip](#start_trip)
+* [update_trip_telemetry](#update_trip_telemetry)
 * [service_areas](#service_areas)
+* [Event types](#Event-Types)
 * [Enum definitions](#enum-definitions)
 
 ## register_vehicle
@@ -27,36 +24,42 @@ The Vehicle Registration API is required in order to register a vehicle for use 
 
 Endpoint: `/register_vehicle`  
 Method: `POST`  
+API Key: `Required`  
 Body:
 
 | Field | Type     | Required/Optional | Other |
 | ----- | -------- | ----------------- | ----- |
-| `provider_id` | UUID | Required | Issued by Provider Registration API |
-| `api_key` | String | Required | API key issued to provider using API Key Registration API |
+| `unique_id` | UUID | UUID v4 provided by Operator to uniquely identify a vehicle |
+| `provider_id` | String | Required | Issued by city |
+| `vehicle_id` | String |  | Vehicle Identification Number (VIN) visible on device|
 | `vehicle_type` | Enum | Required | Vehicle Type |
 | `propulsion_type` | Enum | Required | Propulsion Type |
 | `vehicle_year` | Enum | Required | Year Manufactured |
 | `vehicle_mfgr` | Enum | Required | Vehicle Manufacturer |
 | `vehicle_model` | Enum | Required | Vehicle Model |
-| `vin` | String | Required | Vehicle Identification Number assigned by Manufacturer or Operator |
 
 Response:
 
 | Field | Type     | Required/Optional | Other |
 | ----- | -------- | ----------------- | ----- |
-| `vehicle_id` | UUID |  | Used for accessing vehicle operations API's |
+| `message` | Enum |  | See [Message](#message) Enum |
+
 
 ## deregister_vehicle
 
-The deregister_vehicle API is used to deregister a vehicle from the fleet.
+The remove-vehicle API is used to deregister a vehicle from the fleet.
 
-Endpoint: `/remove_vehicle`  
+Endpoint: `/deregister_vehicle`  
 Method: `POST`  
+API Key: `Required`  
 Body:
 
 | Field | Type     | Required/Optional | Other |
 | ----- | -------- | ----------------- | ----- |
-| `vehicle_id` | String | Required | Issued by RegisterVehicle() API |
+| `unique_id` | UUID | ID used in [Register](#register_vehicle) |
+| `device_id` | UUID | Required | |
+| `reason_code` | Enum | Required | [Reason](#reason_code) for status change  |
+
 
 Response:
 
@@ -64,21 +67,23 @@ Response:
 | ----- | -------- | ----------------- | ----- |
 | `message` | Enum |  | See [Message](#message) Enum |
 
-## service_vehicle
+## update_vehicle_status
 
 This API is used by providers when a vehicle is either removed or returned to service.
 
-Endpoint: `/service_vehicle`  
-Method: `POST`  
+Endpoint: `/update_vehicle_status`  
+Method: `POST`
+API Key: `Required`
 Body:
 
-| Field | Type | Required/Optional | Other | 
-| ----- | ---- | ----------------- | ----- | 
-| `vehicle_id` | UUID | Required | Provided by the Vehicle Registration API | 
-| `timestamp` | Unix Timestamp | Required | Time of day (UTC) data was sampled | 
-| `gps_pos` | Point | Required | GPS location at the time of status change  |
+| Field | Type | Required/Optional | Other |
+| ----- | ---- | ----------------- | ----- |
+| `unique_id` | UUID | ID used in [Register](#register_vehicle) |
+| `timestamp` | Unix Timestamp | Required | Date/time that event occurred. Based on GPS clock. |
+| `location` | Point | Required | Location at the time of status change in WGS 84 (EPSG:4326) standard GPS projection  |
+| `event_type` | Enum | Required | [Event Type](#event_type) for status change.  |
 | `reason_code` | Enum | Required | [Reason](#reason_code) for status change.  |
-| `service_start` | Boolean | Required | `True` if service start, `False` if return from servicing |
+| `battery_pct` | Float | Require if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 
 Response:
 
@@ -86,163 +91,144 @@ Response:
 | ----- | -------- | ----------------- | ----- |
 | `message` | Enum |  | See [Message](#message) Enum |
 
-## report_maintenance
+## start_trip
 
-Used to report maintenance events.
-
-Endpoint: `/report_maintenance`  
-Method: `POST`  
+Endpoint: `/start_trip`  
+Method: `POST`
+API Key: `Required`
 Body:
 
-| Field | Type | Required/Optional | Other | 
-| ----- | ---- | ----------------- | ----- | 
-| `vehicle_id` | UUID | Required | Provided by the Vehicle Registration API | 
-| `timestamp` | Unix Timestamp | Required | Time of day (UTC) data was sampled | 
-| `maint_type` | Enum | Required | Type of Maintenance performed (`Tire`, `Wheel`, `Brake`, `Frame`, `Controls`, `Propulsion`.) | 
-| `maint_action` | Enum | Required | Maintenance action performed (`Repair`, `Replace`, `Inspect`) | 
+| Field | Type | Required/Optional | Other |
+| ----- | ---- | ----------------- | ----- |
+| `unique_id` | UUID | ID used in [Register](#register_vehicle) |
+| `provider_id` | String | Required | Issued by city |
+| `vehicle_id` | String | Required | Provided by the Vehicle Registration API |
+| `timestamp` | Unix Timestamp | Required | Date/time that event occurred. Based on GPS clock. |
+| `location` | Point | Required | Location at the time of status change in WGS 84 (EPSG:4326) standard GPS projection  |
+| `accuracy` | Integer | Required | The approximate level of accuracy, in meters, represented by start_point and end_point. |
+| `battery_pct_start` | Float | Require if Applicable | Percent battery charge of device, expressed between 0 and 1 |
+
 
 Response:
 
 | Field | Type     | Required/Optional | Other |
 | ----- | -------- | ----------------- | ----- |
-| `message` | Enum |  | See [Message](#message) Enum |
+| `trip_id` | UUID | Required | a unique ID for each trip |
 
-## pilot_movement_plan
 
-The pilot_movement_plan API is used for initiating a trip request from a human piloted vehicle. It will be required for ALL trips at the time of departure. The API will acknowledge the request with a response containing a permission to proceed and a unique Trip Identifier.
+## end_trip
 
-Endpoint: `/pilot_movement_plan`  
-Method: `POST`  
+Endpoint: `/end_trip`  
+Method: `POST`
+API Key: `Required`
 Body:
 
-| Field | Type     | Required/Optional | Other |
-| ----- | -------- | ----------------- | ----- |
-| `provider_id` | String | Required | Issued by Provider Registration API |
-| `vehicle_id` | String | Required | Issued by Vehicle Registration API | 
-| `start_point` | Point | Required | Trip Origin | 
-| `est_departure_time` | Unix Timestamp | Required | Estimated Departure Time |  
-| `end_point` | Point | Optional  | Trip destination if known | 
+| Field | Type | Required/Optional | Other |
+| ----- | ---- | ----------------- | ----- |
+| `trip_id` | UUID | Required | See [start_trip](#start_trip) |
+| `timestamp` | Unix Timestamp | Required | Date/time that event occurred. Based on GPS clock. |
+| `location` | Point | Required | Location at the time of status change in WGS 84 (EPSG:4326) standard GPS projection  |
+| `accuracy` | Integer | Required | The approximate level of accuracy, in meters, represented by start_point and end_point. |
+| `battery_pct_end` | Float | Require if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 
-Response: 
-
-| Field | Type     | Required/Optional | Other |
-| ----- | -------- | ----------------- | ----- |
-| `trip_id` | UUID |  | a unique ID for each trip | 
-
-## activate_movement_plan
-
-This API will take an initialized API using `trip_id` as a reference and will activate it, meaning that the trip is in motion.  This API can also be used to re-activate a deactivated movement plan.
-
-Endpoint: `/activate_movement_plan`  
-Method: `POST`  
-Body:
-
-| Field | Type     | Required/Optional | Other |
-| ----- | -------- | ----------------- | ----- |
-| `trip_id` | UUID |  | Issued by pilot_movement_plan API | 
-
-Response:
-
-| Field | Type     | Required/Optional | Other |
-| ----- | -------- | ----------------- | ----- |
-| `message` | Enum |  | See [Message](#message) Enum |
-
-## close_movement_plan 
-
-This API will close a Movement Plan for a given `trip_id`. The response includes a warning whether parking is enforced for the given GPS Position.
-
-Endpoint: `/close_movement_plan`  
-Method: `POST`  
-Body:
-
-| Field | Type     | Required/Optional | Other |
-| ----- | -------- | ----------------- | ----- |
-| `trip_id` | UUID |  | Issued by InitMovementPlan() API | 
-| `timestamp` | Unix Timestamp | Required | Time of day (UTC) data was sampled| 
-| `location` | Point | Required | GPS location in decimal degrees at time of sample  |
-
-Response:
-
-| Field | Type     | Other |
-| ----- | -------- | ----- |
-| `message` | Enum | See [Message](#message) Enum |
-
-## update_trip_data
+## update_trip_telemetry
 
 A trip represents a route taken by a provider's customer.   Trip data will be reported to the API every 5 seconds while the vehicle is in motion.   
 
-Endpoint: `/update_trip_data`  
-Method: `POST`  
+Endpoint: `/update_trip_telemetry`  
+Method: `POST`
+API Key: `Required`
 Body:
 
 | Field | Type     | Required/Optional | Other |
 | ----- | -------- | ----------------- | ----- |
-| `trip_id` | UUID | Required | Issued by InitMovementPlan() API  | 
+| `trip_id` | UUID | Required | Issued by InitMovementPlan() API  |
 | `timestamp` | Unix Timestamp | Required | Time of day (UTC) data was sampled|
-| `location` | Point | Required | GPS location in decimal degrees at time of sample  |
+| `route` | Route | Required | See detail below. |
+| `accuracy` | Integer | Required | The approximate level of accuracy, in meters, represented by start_point and end_point. |
 
 Response:
 
-| Field | Type | Other | 
+| Field | Type | Other |
 | ---- | --- | --- |
-| `message` | Enum | See [Message](#message) Enum | 
+| `message` | Enum | See [Message](#message) Enum |
 
-## check_parking
 
-This API is used to determine whether parking is regulated for a given destination.
+### Route
 
-Endpoint: `/check_parking`  
-Method: `POST`  
-Body:
+To represent a route, MDS provider APIs should create a GeoJSON Feature Collection where ever observed point in the route, plus a time stamp, should be included. The representation needed is below.
 
-| Field | Type     | Required/Optional | Other |
-| ----- | -------- | ----------------- | ----- |
-| `location` | Point  | Required | Current Location  | 
-| `timestamp` | Unix Timestamp | Required | Time of day (UTC) data was sampled|
+The route must include at least 2 points, a start point and end point. Additionally, it must include all possible GPS samples collected by a provider. All points must be in WGS 84 (EPSG:4326) standard GPS projection
+```
 
-Response: 
-
-| Field | Type     | Required/Optional | Other |
-| ----- | -------- | ----------------- | ----- |
-| `message` | Enum | | See [Message](#message) Enum | 
-
-## get_parking_info
-
-This API returns a list of approved parking spaces based on post parameters.
-
-Endpoint: `/get_parking_info`  
-Method: `POST`  
-Body: 
-
-| Field | Type     | Required/Optional | Other |
-| ----- | -------- | ----------------- | ----- |
-| `trip_id` | UUID | Required | Issued by InitMovementPlan() API | 
-| `timestamp` | Unix Timestamp | Required | Time of day (UTC) data was sampled|
-| `gps_pos` | DDD.DDDDD° | Required | GPS location in decimal degrees at time of sample |
-| `park_option` | Enum | Required | Choose the type of parking place desired (`closest`, `least expensive`) |
-
-Reponse: 
-
-| Field | Type     | Required/Optional | Other |
-| ----- | -------- | ----------------- | ----- |
-| `gps_pos` | DDD.DDDDD° |  | GPS location of acceptable parking place |
-| `price` | Decimal |  | Price (Amount) |
-| `currency` | Enum |  | (`USD`, `CAD`) |
-
+"route": {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {
+                    "timestamp": 1529968782.421409
+                },
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        -118.46710503101347,
+                        33.9909333514159
+                    ]
+                }
+            },
+            {
+                "type": "Feature",
+                "properties": {
+                    "timestamp": 1531007628.3774529
+                },
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        -118.464851975441,
+                        33.990366257735
+                    ]
+                }
+            }
+        ] }
+```
 ## service_areas
 
 Gets the list of service areas available to the provider.
 
 Endpoint: `/service_areas`  
 Method: `GET`  
-Body: 
+Body:
 
-| Field | Type | Required/Optional | Other | 
-| ----- | ---- | ----------------- | ----- | 
-| `operator_name` | String | Required |  |
-| `service_area_id` | UUID | Required |  | 
-| `service_start_date` | Unix Timestamp | Required | Date at which this service area became effective | 
+| Field | Type | Required/Optional | Other |
+| ----- | ---- | ----------------- | ----- |
+| `provider_id` | String | Required | Issued by city |
+| `service_area_id` | UUID | Required |  |
+| `service_start_date` | Unix Timestamp | Required | Date at which this service area became effective |
 | `service_end_date` | Unix Timestamp | Required | Date at which this service area was replaced. If currently effective, place NaN |
+| `service_area` | MultiPolygon | Required | |
+| `prior_service_area` | UUID | Optional | If exists, the UUID of the prior service area. |
+| `replacement_service_area` | UUID | Optional | If exists, the UUID of the service area that replaced this one |
+
+### Event Types
+
+| event_type | event_type_description |  reason | reason_description	|
+| ---------- | ---------------------- | ------- | ------------------  |
+| `available` |	A device becomes available for customer use	| `service_start` |	Device introduced into service at the beginning of the day (if program does not operate 24/7) |
+| | | `user_drop_off` |	User ends reservation |
+| | | `rebalance_drop_off` |	Device moved for rebalancing |
+| | | `maintenance_drop_off` | 	Device introduced into service after being removed for maintenance |
+| `reserved` | A customer reserves a device (even if trip has not started yet) |	`user_pick_up` |	Customer reserves device |
+| `unavailable` |	A device is on the street but becomes unavailable for customer use | `default` |  Default state for a newly registered vehicle	|
+| | | `low_battery` | A device is no longer available due to insufficient battery |
+| | | ``maintenance`` | A device is no longer available due to equipment issues |
+| `removed` | A device is removed from the street and unavailable for customer use | `service_end`	| Device removed from street because service has ended for the day (if program does not operate 24/7) |
+| | | `rebalance_pick_up` |	Device removed from street and will be placed at another location to rebalance service |
+| | | `maintenance_pick_up`	 | Device removed from street so it can be worked on |
+| `inactive` | A device has been deregistered  | 	|  |
+
+## Enum Definitions
+=======
 | `service_area` | MultiPolygon | Required | | 
 | `prior_service_area` | UUID | Optional | If exists, the UUID of the prior service area. | 
 | `replacement_service_area` | UUID | Optional | If exists, the UUID of the service area that replaced this one | 
@@ -272,6 +258,9 @@ For 'message', options are:
 * `200: OK`
 * `201: Created`
 * `202: Accepted`
-* `240: Parking NOT enforced for this location`
-* `241: Parking enforced for this location`
-
+* `203: Added`
+* `204: Removed`
+* `210: Warning: vehicle used in this trip has not been properly registered`
+* `310: Error: vehicle is not properly registered`
+* `315: Error: vehicle is not active`
+* `320: Error: vehicle trip has not been properly started`

--- a/agency/README.md
+++ b/agency/README.md
@@ -9,7 +9,7 @@ This specification contains a collection of RESTful APIs used to specify the dig
 ## Table of Contents
 
 * [register_vehicle](#register_vehicle)
-* [remove_vehicle](#remove_vehicle)
+* [deregister_vehicle](#deregister_vehicle)
 * [service_vehicle](#service_vehicle)
 * [report_maintenance](#report_maintenance)
 * [pilot_movement_plan](#pilot_movement_plan)
@@ -46,9 +46,9 @@ Response:
 | ----- | -------- | ----------------- | ----- |
 | `vehicle_id` | UUID |  | Used for accessing vehicle operations API's |
 
-## remove_vehicle
+## deregister_vehicle
 
-The remove_vehicle API is used to deregister a vehicle from the fleet.
+The deregister_vehicle API is used to deregister a vehicle from the fleet.
 
 Endpoint: `/remove_vehicle`  
 Method: `POST`  

--- a/provider/README.md
+++ b/provider/README.md
@@ -1,21 +1,75 @@
 # Mobility Data Specification: **Provider**
 
-This specification contains a data standard for *mobility as a service* providers to define a RESTful API that municipalities can access during the pilot phases of a program.
-
-* Authors: LADOT
-* Date: 23 May 2018
-* Version: ALPHA
-
-## Notes
-
-* All response fields should use `lower_case_with_underscores` to implement the API
-* Responses may be paginated
+This specification contains a data standard for *mobility as a service* providers to define a RESTful API for municipalities to access on-demand.
 
 ## Table of Contents
 
+* [General Information](#general-information)
 * [Trips](#trips)
-* [Availability](#availability)
-* [Service Areas](#service-areas)
+* [Status Changes](#status-changes)
+
+## General Information
+
+The following information applies to all `provider` API endpoints.
+
+### Response Format
+
+Responses must be `UTF-8` encoded `application/json` and must minimally include the MDS `version` and a `data` payload:
+
+```js
+{
+    "version": "0.1.0",
+    "data": {
+        "trips": [{
+            "company_name": "...",
+            "trip_id": "...",
+            //etc.
+        }]
+    }
+}
+```
+
+All response fields must use `lower_case_with_underscores`.
+
+### Pagination
+
+`provider` APIs may decide to paginate the data payload. If so, pagination must comply with the [JSON API](http://jsonapi.org/format/#fetching-pagination) specification.
+
+The following keys must be used for pagination links:
+
+ - `first`: url to the first page of data
+ - `last`: url to the last page of data
+ - `prev`: url to the previous page of data
+ - `next`: url to the next page of data
+
+```js
+{
+    "version": "0.1.0",
+    "data": {
+        "trips": [{
+            "company_name": "...",
+            "trip_id": "...",
+            //etc.
+        }]
+    },
+    "first": "https://...",
+    "last": "https://...",
+    "prev": "https://...",
+    "next": "https://..."
+}
+```
+
+### UUIDs for Devices
+
+**MDS** defines the *device* as the unit that transmits GPS signals for a particular vehicle. A given device must have a UUID (`device_id` below) that is unique within the Provider's fleet.
+
+Additionally, `device_id` must remain constant for the device's lifetime of service, regardless of the vehicle components that house the device.
+
+### Geographic Data
+
+References to geographic datatypes (Point, MultiPolygon, etc.) imply coordinates encoded in the [WGS 84 (EPSG:4326)](https://en.wikipedia.org/wiki/World_Geodetic_System) standard GPS projection expressed as [Decimal Degrees](https://en.wikipedia.org/wiki/Decimal_degrees).
+
+[Top][toc]
 
 ## Trips
 
@@ -25,119 +79,127 @@ The trips API allows a user to query historical trip data. The API should allow 
 
 Endpoint: `/trips`  
 Method: `GET`  
-Response:
+Data: `{ "trips": [] }`, an array of objects with the following structure
 
-| Field | Type     | Required/Optional | Other |
+| Field | Type    | Required/Optional | Comments |
 | ----- | -------- | ----------------- | ----- |
-| `company_name` | String | Required | |
-| `device_type` | String | Required | | 
-| `trip_id` | UUID | Required | a unique ID for each trip | 
-| `trip_duration` | Integer | Required | Time, in Seconds | 
-| `trip_distance` | Integer | Required | Trip Distance, in Meters | 
-| `route` | Route | Required | See detail below. | 
-| `accuracy` | Integer | Required | The approximate level of accuracy, in meters, represented by start_point and end_point. |
-| `device_id` | UUID | Required | | 
-| `start_time` | Unix Timestamp | Required | | 
+| `provider_name` | String | Required | The public-facing name of the Provider |
+| `provider_id` | UUID | Required | A UUID for the Provider, unique within MDS |
+| `device_id` | UUID | Required | A unique device ID in UUID format |
+| `vin` | String | Required | Vehicle Identification Number assigned by Provider |
+| `vehicle_type` | Enum | Required | see [vehicle types](#vehicle-types) table |
+| `propulsion_type` | Enum | Required | see [propulsion types](#propulsion-types) table |
+| `trip_id` | UUID | Required | a unique ID for each trip |
+| `trip_duration` | Integer | Required | Time, in Seconds |
+| `trip_distance` | Integer | Required | Trip Distance, in Meters |
+| `route` | Route | Required | See detail below |
+| `accuracy` | Integer | Required | The approximate level of accuracy, in meters, represented by start_point and end_point |
+| `start_time` | Unix Timestamp | Required | |
 | `end_time` | Unix Timestamp | Required | |
-| `parking_verification` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking | 
-| `standard_cost` | Integer | Optional | The cost, in cents that it would cost to perform that trip in the standard operation of the System. | 
-| `actual_cost` | Integer | Optional | The actual cost paid by the user of the Mobility as a service provider |
+| `parking_verification_url` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking |
+| `standard_cost` | Integer | Optional | The cost, in cents, that it would cost to perform that trip in the standard operation of the System |
+| `actual_cost` | Integer | Optional | The actual cost, in cents, paid by the customer of the *mobility as a service* provider |
+
+### Vehicle Types
+
+| vehicle_type | description |
+|-------|-------------|
+| bicycle | |
+| scooter | |
+| recumbent | |
+
+### Propulsion Types
+
+| propulsion_type | description |
+|-------|-------------|
+| human | |
+| electric | |
+| combustion | |
 
 ### Routes
 
-To represent a route, MDS provider APIs should create a GeoJSON Feature Collection where ever observed point in the route, plus a time stamp, should be included. The representation needed is below.
+To represent a route, MDS `provider` APIs should create a GeoJSON Feature Collection, which includes every observed point in the route, and a timestamp. 
 
-The route must include at least 2 points, a start point and end point. Additionally, it must include all possible GPS samples collected by a provider. All points must be in WGS 84 (EPSG:4326) standard GPS projection 
-```
+Routes must include at least 2 points: the start point and end point. Additionally, routes must include all possible GPS samples collected by a provider.
 
+```js
 "route": {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "properties": {
-                    "timestamp": 1529968782.421409
-                },
-                "geometry": {
-                    "type": "Point",
-                    "coordinates": [
-                        -118.46710503101347,
-                        33.9909333514159
-                    ]
-                }
-            },
-            {
-                "type": "Feature",
-                "properties": {
-                    "timestamp": 1531007628.3774529
-                },
-                "geometry": {
-                    "type": "Point",
-                    "coordinates": [
-                        -118.464851975441,
-                        33.990366257735
-                    ]
-                }
-            }
-        ] }
+    "type": "FeatureCollection",
+    "features": [{
+        "type": "Feature",
+        "properties": {
+            "timestamp": 1529968782.421409
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -118.46710503101347,
+                33.9909333514159
+            ]
+        }
+    },
+    {
+        "type": "Feature",
+        "properties": {
+            "timestamp": 1531007628.3774529
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -118.464851975441,
+                33.990366257735
+            ]
+        }
+    }]
+}
 ```
 
-## Status Change
+[Top][toc]
 
-Status  is the inventory of vehicles available for customer use.
+## Status Changes
 
-The  API allows a user to query the historical availability for a system within a time range. The API should allow queries at least by time period and geographical area.
+The status of the inventory of vehicles available for customer use.
+
+This API allows a user to query the historical availability for a system within a time range. The API should allow queries at least by time period and geographical area.
 
 Endpoint: `/status_changes`  
 Method: `GET`  
-Response:
+Data: `{ "status_changes": [] }`, an array of objects with the following structure
 
-| Field | Type | Required/Optional | Other | 
-| ----- | ---- | ----------------- | ----- | 
-| `device_id` | UUID	| Required | Should be the same as in Trips | 	
-| `device_type` | Enum |	Required | | 	
-| `event_type` | Enum |	Required | 	One of four possible types, see event type table  |
-| `reason` |	Enum |	Required |	Reason for status change.  Allowable values determined by event_type | 
-| `event_time` | Unix Timestamp |	Required | Date/time that event occurred.  Based on GPS clock. 
-| `location` | Point | Required | Must be in WGS 84 (EPSG:4326) standard GPS projection |
-| `battery_pct`	| Float | Required if Applicable | 	Percent battery charge of device, expressed between 0 and 1 | 
-| `associated_trips` | 	UUID |	Optional based on device | 	For “Reserved” event types, associated trips (foreign key to Trips API) | 
-| `company_name` | String | Required | Company Name | 
+| Field | Type | Required/Optional | Comments |
+| ----- | ---- | ----------------- | ----- |
+| `provider_name` | String | Required | The public-facing name of the Provider |
+| `provider_id` | UUID | Required | A UUID for the Provider, unique within MDS |
+| `vin` | String | Required | Vehicle Identification Number assigned by Provider |
+| `device_id` | UUID | Required | A unique device ID in UUID format |
+| `vehicle_type` | Enum | Required | see [vehicle types](#vehicle-types) table |
+| `propulsion_type` | Enum | Required | see [propulsion types](#propulsion-types) table |
+| `event_type` | Enum | Required | See [event types](#event-types) table |
+| `reason` | Enum | Required | Reason for status change, allowable values determined by `event_type` |
+| `event_time` | Unix Timestamp | Required | Date/time that event occurred, based on device clock |
+| `location` | Point | Required | |
+| `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
+| `associated_trips` | UUID | Optional based on device | For "Reserved" event types, associated trips (foreign key to Trips API) |
 
-### Event Types
+### Event Types 
 
-| event_type | event_type_description |  reason | reason_description	|
-| ---------- | ---------------------- | ------- | ------------------  |
-| `available` |	A device becomes available for customer use	| `service_start` |	Device introduced into service at the beginning of the day (if program does not operate 24/7) | 
-| | | `user_drop_off` |	User ends reservation | 
-| | | `rebalance_drop_off` |	Device moved for rebalancing | 
-| | | `maintenance_drop_off` | 	Device introduced into service after being removed for maintenance | 
-| `reserved` | A customer reserves a device (even if trip has not started yet) |	`user_pick_up` |	Customer reserves device | 
-| `unavailable` |	A device is on the street but becomes unavailable for customer use | `maintenance` |	A device is no longer available due to equipment issues |
-| | | `low_battery` | A device is no longer available due to insufficient battery | 
-| `removed` | A device is removed from the street and unavailable for customer use | `service_end`	| Device removed from street because service has ended for the day (if program does not operate 24/7) | 
-| | | `rebalance_pick_up` |	Device removed from street and will be placed at another location to rebalance service | 
-| | | `maintenance_pick_up`	 | Device removed from street so it can be worked on | 
+| event_type | event_type_description | reason | reason_description |
+| ---------- | ---------------------- | ------- | ------------------ |
+| `available` | A device becomes available for customer use | `service_start` | Device introduced into service at the beginning of the day (if program does not operate 24/7) |
+| | | `user_drop_off` | User ends reservation |
+| | | `rebalance_drop_off` | Device moved for rebalancing |
+| | | `maintenance_drop_off` | Device introduced into service after being removed for maintenance |
+| `reserved` | A customer reserves a device (even if trip has not started yet) | `user_pick_up` | Customer reserves device |
+| `unavailable` | A device is on the street but becomes unavailable for customer use | `maintenance` | A device is no longer available due to equipment issues |
+| | | `low_battery` | A device is no longer available due to insufficient battery |
+| `removed` | A device is removed from the street and unavailable for customer use | `service_end` | Device removed from street because service has ended for the day (if program does not operate 24/7) |
+| | | `rebalance_pick_up` | Device removed from street and will be placed at another location to rebalance service |
+| | | `maintenance_pick_up` | Device removed from street so it can be worked on |
 
 ### Realtime Data
 
-All MDS compatible APIs should expose a GBFS feed as well. For historical data, a `time` parameter should be provided to access what the GBFS feed showed at a given time.
+All MDS compatible `provider` APIs must expose a [GBFS](https://github.com/NABSA/gbfs) feed as well. For historical data, a `time` parameter should be provided to access what the GBFS feed showed at a given time.
 
-## Service Areas 
+[Top][toc]
 
-Service areas are the geographic regions within which a *mobility as a service* provider is permitted to operate. 
-
-Endpoint: `/service_areas`  
-Method: `GET`  
-Response:
-
-| Field | Type | Required/Optional | Other | 
-| ----- | ---- | ----------------- | ----- | 
-| `operator_name` | String | Required |  |
-| `service_area_id` | UUID | Required |  | 
-| `service_start_date` | Unix Timestamp | Required | Date at which this service area became effective | 
-| `service_end_date` | Unix Timestamp | Required | Date at which this service area was replaced. If current effictive, place NaN | 
-| `service_area` | MultiPolygon | Required | Must be in WGS 84 (EPSG:4326) standard GPS projection | 
-| `prior_service_area` | UUID | Optional | If exists, the UUID of the prior service area. | 
-| `replacement_service_area` | UUID | Optional | If exists, the UUID of the service area that replaced this one | 
-
+[toc]: #table-of-contents

--- a/provider/README.md
+++ b/provider/README.md
@@ -52,7 +52,7 @@ Status  is the inventory of vehicles available for customer use.
 
 The  API allows a user to query the historical availability for a system within a time range. The API should allow queries at least by time period and geographical area.
 
-Endpoint: `/status-changes`  
+Endpoint: `/status_changes`  
 Method: `GET`  
 Response:
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -67,7 +67,8 @@ Response:
 | `battery_pct`	| Float | Required if Applicable | 	Percent battery charge of device, expressed between 0 and 1 | 
 | `associated_trips` | 	UUID |	Optional based on device | 	For “Reserved” event types, associated trips (foreign key to Trips API) | 
 | `company_name` | String | Required | Company Name | 
-### Event Types 
+
+### Event Types
 
 | event_type | event_type_description |  reason | reason_description	|
 | ---------- | ---------------------- | ------- | ------------------  |


### PR DESCRIPTION
It doesn't make sense to have all the responses use snake case (underscores) with endpoints with dashes.

Partially because consistency but also because most web frameworks use underscores. The only one I'm aware of that uses dashes is Django, and [that seems somewhat contentious](https://medium.com/@raiderrobert/django-url-names-should-be-underscore-separated-7815e3d4e7c2)