### PR TITLE
Change device_id to VIN

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -39,12 +39,8 @@ Body:
 | `vehicle_mfgr` | Enum | Required | Vehicle Manufacturer |
 | `vehicle_model` | Enum | Required | Vehicle Model |
 | `vin` | String | Required | Vehicle Identification Number assigned by Manufacturer or Operator |
+| `device_id` | UUID | Required | UUID geneated by requestor to uniquely identify the device. Must be consistent with that physical device. If UUID is not unique, API will return a status code not equal to `200` | 
 
-Response:
-
-| Field | Type     | Required/Optional | Other |
-| ----- | -------- | ----------------- | ----- |
-| `vehicle_id` | UUID |  | Used for accessing vehicle operations API's |
 
 ## remove-vehicle
 
@@ -56,7 +52,7 @@ Body:
 
 | Field | Type     | Required/Optional | Other |
 | ----- | -------- | ----------------- | ----- |
-| `vehicle_id` | String | Required | Issued by RegisterVehicle() API |
+| `device_id` | UUID | Required | Issued by RegisterVehicle() API |
 | `reason_code` | Enum | Required | [Reason](#reason_code) for status change  |
 
 Response:
@@ -75,7 +71,7 @@ Body:
 
 | Field | Type | Required/Optional | Other | 
 | ----- | ---- | ----------------- | ----- | 
-| `vehicle_id` | UUID | Required | Provided by the Vehicle Registration API | 
+| `device_id` | UUID | Required | | 
 | `timestamp` | Unix Timestamp | Required | Time of day (UTC) data was sampled | 
 | `gps_pos` | Point | Required | GPS location at the time of status change  |
 | `reason_code` | Enum | Required | [Reason](#reason_code) for status change.  |
@@ -97,7 +93,7 @@ Body:
 
 | Field | Type | Required/Optional | Other | 
 | ----- | ---- | ----------------- | ----- | 
-| `vehicle_id` | UUID | Required | Provided by the Vehicle Registration API | 
+| `device_id` | UUID | Required | | 
 | `timestamp` | Unix Timestamp | Required | Time of day (UTC) data was sampled | 
 | `maint_type` | Enum | Required | Type of Maintenance performed (`Tire`, `Wheel`, `Brake`, `Frame`, `Controls`, `Propulsion`.) | 
 | `maint_action` | Enum | Required | Maintenance action performed (`Repair`, `Replace`, `Inspect`) | 
@@ -119,7 +115,7 @@ Body:
 | Field | Type     | Required/Optional | Other |
 | ----- | -------- | ----------------- | ----- |
 | `provider_id` | String | Required | Issued by Provider Registration API |
-| `vehicle_id` | String | Required | Issued by Vehicle Registration API | 
+| `vehicle_id` | UUID | Required | | 
 | `start_point` | Point | Required | Trip Origin | 
 | `est_departure_time` | Unix Timestamp | Required | Estimated Departure Time |  
 | `end_point` | Point | Optional  | Trip destination if known | 

--- a/provider/README.md
+++ b/provider/README.md
@@ -36,8 +36,9 @@ Response:
 | `trip_distance` | Integer | Required | Trip Distance, in Meters | 
 | `route` | Route | Required | See detail below. | 
 | `accuracy` | Integer | Required | The approximate level of accuracy, in meters, represented by start_point and end_point. |
+| `device_id` | UUID | Required | A unique device ID in UUID format. | 
 | `provider_id` | String | Required | Issued by the city during the permitting process |
-| `vehicle_id` | String | Required | Vehicle Identification Number assigned by Manufacturer or Operator| 
+| `vin` | String | Required | Vehicle Identification Number assigned by Manufacturer or Operator| 
 | `start_time` | Unix Timestamp | Required | | 
 | `end_time` | Unix Timestamp | Required | |
 | `parking_verification` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking | 

--- a/provider/README.md
+++ b/provider/README.md
@@ -37,7 +37,7 @@ Response:
 | `route` | Route | Required | See detail below. | 
 | `accuracy` | Integer | Required | The approximate level of accuracy, in meters, represented by start_point and end_point. |
 | `provider_id` | String | Required | Issued by the city during the permitting process |
-| `vehicle_id` | UUID | Required | Vehicle Identification Number assigned by Manufacturer or Operator| 
+| `vehicle_id` | String | Required | Vehicle Identification Number assigned by Manufacturer or Operator| 
 | `start_time` | Unix Timestamp | Required | | 
 | `end_time` | Unix Timestamp | Required | |
 | `parking_verification` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking | 
@@ -95,7 +95,7 @@ Response:
 
 | Field | Type | Required/Optional | Other | 
 | ----- | ---- | ----------------- | ----- | 
-| `device_id` | UUID	| Required | Should be the same as in Trips | 	
+| `vehicle_id` | String | Required | Vehicle Identification Number used in Trips| 	
 | `device_type` | Enum |	Required | | 	
 | `event_type` | Enum |	Required | 	One of four possible types, see event type table  |
 | `reason` |	Enum |	Required |	Reason for status change.  Allowable values determined by event_type | 

--- a/provider/README.md
+++ b/provider/README.md
@@ -36,7 +36,8 @@ Response:
 | `trip_distance` | Integer | Required | Trip Distance, in Meters | 
 | `route` | Route | Required | See detail below. | 
 | `accuracy` | Integer | Required | The approximate level of accuracy, in meters, represented by start_point and end_point. |
-| `device_id` | UUID | Required | | 
+| `provider_id` | String | Required | Issued by Provider Registration API |
+| `vehicle_id` | UUID | Required | Vehicle Identification Number assigned by Manufacturer or Operator| 
 | `start_time` | Unix Timestamp | Required | | 
 | `end_time` | Unix Timestamp | Required | |
 | `parking_verification` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking | 

--- a/provider/README.md
+++ b/provider/README.md
@@ -36,7 +36,7 @@ Response:
 | `trip_distance` | Integer | Required | Trip Distance, in Meters | 
 | `route` | Route | Required | See detail below. | 
 | `accuracy` | Integer | Required | The approximate level of accuracy, in meters, represented by start_point and end_point. |
-| `provider_id` | String | Required | Issued by Provider Registration API |
+| `provider_id` | String | Required | Issued by the city during the permitting process |
 | `vehicle_id` | UUID | Required | Vehicle Identification Number assigned by Manufacturer or Operator| 
 | `start_time` | Unix Timestamp | Required | | 
 | `end_time` | Unix Timestamp | Required | |


### PR DESCRIPTION
Suggesting a change to the identifier for a vehicle away from a UUID and using the operators VIN identifier instead.   The thought here is that each bike manufacturer already has a unique identifier for their vehicle embedded in their code (QR code or otherwise).  It is inherent to the business.   Let's use that number so they could be correlated to real bikes on the street if it ever became necessary.