### PR TITLE
Adding electric_assist as a propulsion_type.

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -112,6 +112,7 @@ Data: `{ "trips": [] }`, an array of objects with the following structure
 | `propulsion_type` |
 |-----------------|
 | human           |
+| electric_assist |
 | electric        |
 | combustion      |
 


### PR DESCRIPTION
Just a small suggestion that it might be useful to distinguish between completely electric vehicles (like Lime and Bird Scooters) and pedal assist vehicles that combine human and electric power (like Jump bikes).

I added `electric_assist` to the `propulsion_type` enum to fix this.

I understand if you want to call both of these kinds of vehicles `electric`, but I think the distinction could be useful!