### PR TITLE
Consider taking out trip_duration

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -90,7 +90,6 @@ Data: `{ "trips": [] }`, an array of objects with the following structure
 | `vehicle_type` | Enum | Required | See [vehicle types](#vehicle-types) table |
 | `propulsion_type` | Enum[] | Required | See [propulsion types](#propulsion-types) table; allows multiple values |
 | `trip_id` | UUID | Required | A unique ID for each trip |
-| `trip_duration` | Integer | Required | Time, in Seconds |
 | `trip_distance` | Integer | Required | Trip Distance, in Meters |
 | `route` | Route | Required | See detail below |
 | `accuracy` | Integer | Required | The approximate level of accuracy, in meters, of `Points` within `route` |


### PR DESCRIPTION
I noticed that the trip schema has `trip_duration`, `start_time`, and `end_time`. I may be misunderstanding what these fields mean, but it seems like they may be redundant, as the trip duration should just be end time minus start time.

In this PR, I suggest removing `trip_duration`, although you could remove `end_time` (or even `start_time`, but that would be... strange :) ).