### PR TITLE
Add detail to query params for providers

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -113,7 +113,8 @@ The trips API should allow querying trips with a combination of query parameters
 * `start_location`
 * `end_location`
 
-All of these query params will use the *Type* listed above with the exception of `start_location` and `end_location` which can be provided as stringified GeoJson Polygons.
+All of these query params will use the *Type* listed above with the exception of `start_location` and `end_location` which can be provided as stringified bounding-box. For example `-122.4183,37.7758,-122.4120,37.7858` would get all trips within that bound box. The order is definied as  southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas). 
+
 
 ### Vehicle Types
 
@@ -204,7 +205,8 @@ The status_changes API should allow querying status changes with a combination o
 * `end_time`
 * `location`
 
-The `time` parameters can be provided as Unix Timestamps individually or together. The `location` parameter can be provided as a stringified GeoJson Polygon.
+The `time` parameters can be provided as Unix Timestamps individually or together. The `location` parameter which can be provided as stringified bounding box lat/longs. For example `-122.4183,37.7758,-122.4120,37.7858` would get all trips within that bound box. The order is definied as  southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas). 
+
 
 ### Event Types
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -109,11 +109,12 @@ The trips API should allow querying trips with a combination of query parameters
 * `device_id`
 * `vehicle_id`
 * `start_time`
-* `end_time`
-* `start_location`
+* `bbox`
 * `end_location`
 
-All of these query params will use the *Type* listed above with the exception of `start_location` and `end_location` which can be provided as stringified bounding-box. For example `-122.4183,37.7758,-122.4120,37.7858` would get all trips within that bound box. The order is definied as  southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas). 
+All of these query params will use the *Type* listed above with the exception of `bbox`, which is the bounding box.
+
+For example `-122.4183,37.7758,-122.4120,37.7858` would get all trips within that bound box where any point inside the `route` is inside said box. The order is definied as  southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas). 
 
 
 ### Vehicle Types
@@ -203,9 +204,11 @@ The status_changes API should allow querying status changes with a combination o
 
 * `start_time`
 * `end_time`
-* `location`
+* `bbox`
 
-The `time` parameters can be provided as Unix Timestamps individually or together. The `location` parameter which can be provided as stringified bounding box lat/longs. For example `-122.4183,37.7758,-122.4120,37.7858` would get all trips within that bound box. The order is definied as  southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas). 
+The `time` parameters can be provided as Unix Timestamps individually or together. 
+
+The `bbox` parameter which can be provided as stringified bounding-box lat/longs. For example `-122.4183,37.7758,-122.4120,37.7858` would get all trips within that bound box. The order is definied as  southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas). 
 
 
 ### Event Types

--- a/provider/README.md
+++ b/provider/README.md
@@ -109,12 +109,18 @@ The trips API should allow querying trips with a combination of query parameters
 * `device_id`
 * `vehicle_id`
 * `start_time`
+* `end_time`
 * `bbox`
-* `end_location`
 
-All of these query params will use the *Type* listed above with the exception of `bbox`, which is the bounding box.
+All of these query params will use the *Type* listed above with the exception of `bbox`, which is the bounding-box.
 
-For example `-122.4183,37.7758,-122.4120,37.7858` would get all trips within that bound box where any point inside the `route` is inside said box. The order is definied as  southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas). 
+For example:
+
+```
+bbox=-122.4183,37.7758,-122.4120,37.7858
+```
+
+Gets all trips within that bounding-box where any point inside the `route` is inside said box. The order is definied as: southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas). 
 
 
 ### Vehicle Types
@@ -206,9 +212,15 @@ The status_changes API should allow querying status changes with a combination o
 * `end_time`
 * `bbox`
 
-The `time` parameters can be provided as Unix Timestamps individually or together. 
+The `time` parameters can be provided as timestamps individually or together. 
 
-The `bbox` parameter which can be provided as stringified bounding-box lat/longs. For example `-122.4183,37.7758,-122.4120,37.7858` would get all trips within that bound box. The order is definied as  southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas). 
+`bbox` is the bounding-box, for example:
+
+```
+bbox=-122.4183,37.7758,-122.4120,37.7858
+```
+
+Gets all status changes with an `event_location` within that bounding-box. The order is definied as: southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas). 
 
 
 ### Event Types

--- a/provider/README.md
+++ b/provider/README.md
@@ -77,7 +77,7 @@ References to geographic datatypes (Point, MultiPolygon, etc.) imply coordinates
 
 A trip represents a journey taken by a *mobility as a service* customer with a geo-tagged start and stop point.
 
-The trips API allows a user to query historical trip data. The API should allow querying trips at least by ID, geofence for start or end, and time.
+The trips API allows a user to query historical trip data.
 
 Endpoint: `/trips`  
 Method: `GET`  
@@ -101,6 +101,19 @@ Data: `{ "trips": [] }`, an array of objects with the following structure
 | `parking_verification_url` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking |
 | `standard_cost` | Integer | Optional | The cost, in cents, that it would cost to perform that trip in the standard operation of the System |
 | `actual_cost` | Integer | Optional | The actual cost, in cents, paid by the customer of the *mobility as a service* provider |
+
+### Trips Query Parameters
+
+The trips API should allow querying trips with a combination of query parameters.
+
+* `device_id`
+* `vehicle_id`
+* `start_time`
+* `end_time`
+* `start_location`
+* `end_location`
+
+All of these query params will use the *Type* listed above with the exception of `start_location` and `end_location` which can be provided as stringified GeoJson Polygons.
 
 ### Vehicle Types
 
@@ -162,7 +175,7 @@ Routes must include at least 2 points: the start point and end point. Additional
 
 The status of the inventory of vehicles available for customer use.
 
-This API allows a user to query the historical availability for a system within a time range. The API should allow queries at least by time period and geographical area.
+This API allows a user to query the historical availability for a system within a time range.
 
 Endpoint: `/status_changes`  
 Method: `GET`  
@@ -182,6 +195,16 @@ Data: `{ "status_changes": [] }`, an array of objects with the following structu
 | `event_location` | Point | Required | |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `associated_trips` | UUID[] | Optional based on device | Array of UUID's. For "Reserved" event types, associated trips (foreign key to Trips API) |
+
+### Status Changes Query Parameters
+
+The status_changes API should allow querying status changes with a combination of query parameters.
+
+* `start_time`
+* `end_time`
+* `location`
+
+The `time` parameters can be provided as Unix Timestamps individually or together. The `location` parameter can be provided as a stringified GeoJson Polygon.
 
 ### Event Types
 


### PR DESCRIPTION
For trips and status_changes break query params
	out into their own section.

Add more detail around how to specify time
	and location based parameters.

For location this is just a suggestion.

There may be url length concerns when passing in large polygons
	in query params.

A better approach might be to pass in service_area id or
	use a location filter based on the token and
	filter data further after retrieval

Comments welcome.