### PR TITLE
Adding providers.csv. fixes #39

### DIFF
--- a/providers.csv
+++ b/providers.csv
@@ -1,0 +1,1 @@
+provider_name, provider_id, url, mds_api_url


### PR DESCRIPTION
This pull request adds an empty provider csv file for each operator to add in a PR. 

Each company should provide their name, a UUID ID, url, and their MDS url in a following PR.