### PR TITLE
Add auth.md to document provider authentication

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -10,7 +10,7 @@ This specification contains a data standard for *mobility as a service* provider
 
 ## General Information
 
-The following information applies to all `provider` API endpoints. Details on providing authorization to endpoints is specified in the [auth](auth) document.
+The following information applies to all `provider` API endpoints. Details on providing authorization to endpoints is specified in the [auth](auth.md) document.
 
 ### Response Format
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -10,7 +10,7 @@ This specification contains a data standard for *mobility as a service* provider
 
 ## General Information
 
-The following information applies to all `provider` API endpoints.
+The following information applies to all `provider` API endpoints. Details on providing authorization to endpoints is specified in the [auth](auth) document.
 
 ### Response Format
 

--- a/provider/auth.md
+++ b/provider/auth.md
@@ -1,0 +1,11 @@
+# Authorization
+
+Authorization for **provider** API should be provided via a JSON Web Token or [JWT](https://jwt.io/introduction/).
+
+JWTs provide a safe, secure way to verify the identity of an **agency** and provide access to MDS resources without providing access to other, potentially sensitive data.
+
+> JSON Web Token (JWT) is an open standard ([RFC 7519](https://tools.ietf.org/html/rfc7519)) that defines a compact and self-contained way for securely transmitting information between parties as a JSON object. This information can be verified and trusted because it is digitally signed. JWTs can be signed using a secret (with the HMAC algorithm) or a public/private key pair using RSA or ECDSA.
+
+**Providers** may include any metadata in the JWT they wish that helps to route, log, permission, or debug **agency** requests leaving their internal implementation flexible.
+
+JWT provides a helpful [debugger](https://jwt.io/#debugger). for testing your token and verifying security.

--- a/provider/auth.md
+++ b/provider/auth.md
@@ -1,17 +1,25 @@
 # Authorization
 
+MDS `providers` **SHALL** provide authorization for API endpoints via a bearer token based auth system. 
 
-MDS APIs SHALL provide authorization for **provider** API should be provided via a bearer token based auth system. 
+For example, the `Authorization` header sent as part of an HTTP request:
 
-For example, `Authorization: Bearer <token>` sent in the header of the request. More info on how to document [Bearer Auth](https://swagger.io/docs/specification/authentication/bearer-authentication/). 
+```
+GET /trips HTTP/1.1
+Host: api.provider.co
+Authorization: Bearer <token> 
+```
 
+More info on how to document [Bearer Auth in swagger](https://swagger.io/docs/specification/authentication/bearer-authentication/)
 
-RECOMMENDED : Use JSON Web Tokens or [JWT](https://jwt.io/introduction/) to generate tec
+## JSON Web Tokens
 
-JWTs provide a safe, secure way to verify the identity of an **agency** and provide access to MDS resources without providing access to other, potentially sensitive data.
+JSON Web Token ([JWT](https://jwt.io/introduction/)) is **RECOMMENDED** as the token format.
+
+JWTs provide a safe, secure way to verify the identity of an agency and provide access to MDS resources without providing access to other, potentially sensitive data.
 
 > JSON Web Token (JWT) is an open standard ([RFC 7519](https://tools.ietf.org/html/rfc7519)) that defines a compact and self-contained way for securely transmitting information between parties as a JSON object. This information can be verified and trusted because it is digitally signed. JWTs can be signed using a secret (with the HMAC algorithm) or a public/private key pair using RSA or ECDSA.
 
-**Providers** MAY include any metadata in the JWT they wish that helps to route, log, permission, or debug **agency** requests leaving their internal implementation flexible.
+MDS `providers` **MAY** include any metadata in the JWT they wish that helps to route, log, permission, or debug agency requests, leaving their internal implementation flexible.
 
-JWT provides a helpful [debugger](https://jwt.io/#debugger). for testing your token and verifying security.
+JWT provides a helpful [debugger](https://jwt.io/#debugger) for testing your token and verifying security.

--- a/provider/auth.md
+++ b/provider/auth.md
@@ -1,11 +1,17 @@
 # Authorization
 
-Authorization for **provider** API should be provided via a JSON Web Token or [JWT](https://jwt.io/introduction/).
+
+MDS APIs SHALL provide authorization for **provider** API should be provided via a bearer token based auth system. 
+
+For example, `Authorization: Bearer <token>` sent in the header of the request. More info on how to document [Bearer Auth](https://swagger.io/docs/specification/authentication/bearer-authentication/). 
+
+
+RECOMMENDED : Use JSON Web Tokens or [JWT](https://jwt.io/introduction/) to generate tec
 
 JWTs provide a safe, secure way to verify the identity of an **agency** and provide access to MDS resources without providing access to other, potentially sensitive data.
 
 > JSON Web Token (JWT) is an open standard ([RFC 7519](https://tools.ietf.org/html/rfc7519)) that defines a compact and self-contained way for securely transmitting information between parties as a JSON object. This information can be verified and trusted because it is digitally signed. JWTs can be signed using a secret (with the HMAC algorithm) or a public/private key pair using RSA or ECDSA.
 
-**Providers** may include any metadata in the JWT they wish that helps to route, log, permission, or debug **agency** requests leaving their internal implementation flexible.
+**Providers** MAY include any metadata in the JWT they wish that helps to route, log, permission, or debug **agency** requests leaving their internal implementation flexible.
 
 JWT provides a helpful [debugger](https://jwt.io/#debugger). for testing your token and verifying security.


### PR DESCRIPTION
Provide information on authentication with JWT and minimal payload.

Update provider/README.md to reference auth.md

Refs Issue [#60](https://github.com/CityOfLosAngeles/mobility-data-specification/issues/60)