### PR TITLE
Elevating Status of Realtime Feed

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -7,6 +7,7 @@ This specification contains a data standard for *mobility as a service* provider
 * [General Information](#general-information)
 * [Trips](#trips)
 * [Status Changes](#status-changes)
+* [Realtime Data](#realtime-data)
 
 ## General Information
 
@@ -267,7 +268,7 @@ Gets all status changes with an `event_location` within that bounding-box. The o
 | | | `rebalance_pick_up` | Device removed from street and will be placed at another location to rebalance service |
 | | | `maintenance_pick_up` | Device removed from street so it can be worked on |
 
-### Realtime Data
+## Realtime Data
 
 All MDS compatible `provider` APIs must expose a [GBFS](https://github.com/NABSA/gbfs) feed as well. For historical data, a `time` parameter should be provided to access what the GBFS feed showed at a given time.
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -270,7 +270,13 @@ Gets all status changes with an `event_location` within that bounding-box. The o
 
 ## Realtime Data
 
-All MDS compatible `provider` APIs must expose a [GBFS](https://github.com/NABSA/gbfs) feed as well. For historical data, a `time` parameter should be provided to access what the GBFS feed showed at a given time.
+All MDS compatible `provider` APIs must expose a public [GBFS](https://github.com/NABSA/gbfs) feed as well. Given that GBFS hasn't fully [evolved to support dockless mobility](https://github.com/NABSA/gbfs/pull/92) yet, we follow the current guidelines in making bike information avaliable to the public. 
+
+  - `system_information.json` is always required
+  - `free_bike_status.json` is required for MDS
+  - `station_information.json` and `station_status.json` don't apply for MDS
+
+
 
 [Top][toc]
 


### PR DESCRIPTION
Suggesting moving the real-time feed from a subsection of the Trips endpoint to its own section to clarify that it is a separate requirement with a separate endpoint