### PR TITLE
 Add service area type to the agency API. Add service areas to the provider API

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -206,7 +206,7 @@ Query Parameters:
 | Parameter | Type | Required/Optional | Description |
 | ----- | ---- | ----------------- | ----- |
 | `provider_id` | UUID | Required | A UUID for the Provider, unique within MDS |
-| `service_area_id` | UUID  | Optional | If provided, retrieve a specific service area (e.g. a retired or old service area). If omitted, will return all active service areas. |  
+| `service_area_id` | UUID  | Optional | If provided, retrieve a specific service area (e.g. a retired or old service area). If omitted, will return all active service areas. |
 
 Response:
 
@@ -218,6 +218,16 @@ Response:
 | `service_area` | MultiPolygon | Required | |
 | `prior_service_area` | UUID | Optional | If exists, the UUID of the prior service area. |
 | `replacement_service_area` | UUID | Optional | If exists, the UUID of the service area that replaced this one |
+| `type` | Enum | Required |  See [area types](#area-types) table |
+
+### Area types
+
+| `type` | Description |
+|------------| ----------- |
+| unrestricted | Areas where devices may be picked up/dropped off. A provider's unrestricted area shall be contained completely inside the agency's unrestricted area for the provider in question, but it need not cover the entire agency unrestricted area. See the provider version of the service areas endpoint |
+| restricted | Areas where device pick-up/drop-off is not allowed |
+| preferred_pick_up | Areas where users are encouraged to pick up devices |
+| preferred_drop_off | Areas where users are encouraged to drop off devices |
 
 ### Event Types
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -270,6 +270,44 @@ bbox=-122.4183,37.7758,-122.4120,37.7858
 | | | `rebalance_pick_up` | Device removed from street and will be placed at another location to rebalance service |
 | | | `maintenance_pick_up` | Device removed from street so it can be worked on |
 
+## Service Areas
+
+Gets the list of service areas available to the provider.
+
+Endpoint: `/service_areas`
+Method: `GET`
+Query Parameters:
+
+| Parameter | Type | Required/Optional | Description |
+| ----- | ---- | ----------------- | ----- |
+| `service_area_id` | UUID  | Optional | If provided, retrieve a specific service area (e.g. a retired or old service area). If omitted, will return all active service areas. |
+
+Response:
+
+| Field | Types  | Required/Optional | Other |
+| ----- | ---- | ----------------- | ----- |
+| `service_area_id` | UUID | Required |  |
+| `service_start_date` | Unix Timestamp | Required | Date at which this service area became effective |
+| `service_end_date` | Unix Timestamp | Required | Date at which this service area was replaced. If currently effective, place NaN |
+| `service_area` | MultiPolygon | Required | |
+| `prior_service_area` | UUID | Optional | If exists, the UUID of the prior service area. |
+| `replacement_service_area` | UUID | Optional | If exists, the UUID of the service area that replaced this one |
+| `type` | Enum | Required |  See [area types](#area-types) table |
+
+### Area types
+
+| `type` | Description |
+|------------| ----------- |
+| unrestricted | Areas where devices may be picked up/dropped off. A provider's unrestricted area shall be contained completely inside the agency's unrestricted area for the provider in question, but it need not cover the entire agency unrestricted area. See the agency version of the service areas endpoint |
+| agency_restricted | Areas where the agency does not allow device pick-up/drop-off |
+| agency_preferred_pick_up | Areas where users are encouraged by the agency to pick up devices |
+| agency_preferred_drop_off | Areas where users are encouraged by the agency to drop off devices |
+| provider_restricted | Areas where the provider does not allow device pick-up/drop-off |
+| provider_preferred_pick_up | Areas where users are encouraged by the provider to pick up devices |
+| provider_preferred_drop_off | Areas where users are encouraged by the provider to drop off devices |
+
+[Top][toc]
+
 ## Realtime Data
 
 All MDS compatible `provider` APIs must expose a public [GBFS](https://github.com/NABSA/gbfs) feed as well. Given that GBFS hasn't fully [evolved to support dockless mobility](https://github.com/NABSA/gbfs/pull/92) yet, we follow the current guidelines in making bike information avaliable to the public. 
@@ -277,8 +315,6 @@ All MDS compatible `provider` APIs must expose a public [GBFS](https://github.co
   - `system_information.json` is always required
   - `free_bike_status.json` is required for MDS
   - `station_information.json` and `station_status.json` don't apply for MDS
-
-
 
 [Top][toc]
 


### PR DESCRIPTION
We propose adding the following functionality to the Service Area API.  The agency API would allow agencies to also indicate restricted zones and preferred pick-up/drop-off zones.  We envision this as a mechanism to communicate both permanent and temporary (e.g., special event) prohibited/incentive zones, rather than ad-hoc communications (e.g., emailing a shapefile).

We presume the providers also have their own prohibited/incentive zones.  The Provider API would return the full set of prohibited/incentive zones (whether indicated by the provider or the agency).
