### PR TITLE
[Agency] API is REST-like, not RESTful

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -1,6 +1,6 @@
 # Mobility Data Specification: **Agency**
 
-This specification contains a collection of RESTful APIs used to specify the digital relationship between *mobility as a service* providers and the agencies that regulate them.
+This specification contains a collection of REST-like APIs used to specify the digital relationship between *mobility as a service* providers and the agencies that regulate them.
 
 * Authors: LADOT
 * Date: 10 Aug 2018


### PR DESCRIPTION
I don't want to go into any bike-shedding, and it does not matter if an API is RESTful or REST-like. That said, it is nice to use the correct term to define the API, and this one is clearly REST-like (otherwise we would have a "/vehicles" resource that we could PUT and DELETE, not "register_vehicle" and "deregister_vehicle")
