### PR TITLE
Standardize line breaks

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -22,9 +22,10 @@ This specification contains a collection of RESTful APIs used to specify the dig
 
 The Vehicle Registration API is required in order to register a vehicle for use in the system. The API will require a valid `provider_id` and `api_key`.
 
-Endpoint: `/register_vehicle`  
-Method: `POST`  
-API Key: `Required`  
+Endpoint: `/register_vehicle`\
+Method: `POST`\
+API Key: `Required`
+
 Body:
 
 | Field | Type     | Required/Optional | Other |
@@ -48,9 +49,10 @@ Response:
 
 The remove-vehicle API is used to deregister a vehicle from the fleet.
 
-Endpoint: `/deregister_vehicle`  
-Method: `POST`  
-API Key: `Required`  
+Endpoint: `/deregister_vehicle`\
+Method: `POST`\
+API Key: `Required`
+
 Body:
 
 | Field | Type     | Required/Optional | Other |
@@ -69,9 +71,10 @@ Response:
 
 This API is used by providers when a vehicle is either removed or returned to service.
 
-Endpoint: `/update_vehicle_status`  
-Method: `PUT`
+Endpoint: `/update_vehicle_status`\
+Method: `PUT`\
 API Key: `Required`
+
 Body:
 
 | Field | Type | Required/Optional | Other |
@@ -91,9 +94,10 @@ Response:
 
 ## start_trip
 
-Endpoint: `/start_trip`  
-Method: `POST`
+Endpoint: `/start_trip`\
+Method: `POST`\
 API Key: `Required`
+
 Body:
 
 | Field | Type | Required/Optional | Other |
@@ -114,9 +118,10 @@ Response:
 
 ## end_trip
 
-Endpoint: `/end_trip`  
-Method: `POST`
+Endpoint: `/end_trip`\
+Method: `POST`\
 API Key: `Required`
+
 Body:
 
 | Field | Type | Required/Optional | Other |
@@ -131,9 +136,10 @@ Body:
 
 A trip represents a route taken by a provider's customer.   Trip data will be reported to the API every 5 seconds while the vehicle is in motion.
 
-Endpoint: `/update_trip_telemetry`  
-Method: `POST`  
-API Key: `Required`  
+Endpoint: `/update_trip_telemetry`\
+Method: `POST`\
+API Key: `Required`
+
 Body:
 
 | Field | Type     | Required/Optional | Other |
@@ -192,8 +198,9 @@ The route must include at least 2 points, a start point and end point. Additiona
 
 Gets the list of service areas available to the provider.
 
-Endpoint: `/service_areas`  
-Method: `GET`  
+Endpoint: `/service_areas`\
+Method: `GET`
+
 Query Parameters:
 
 | Parameter | Type | Required/Optional | Description |

--- a/provider/README.md
+++ b/provider/README.md
@@ -109,9 +109,11 @@ A trip represents a journey taken by a *mobility as a service* customer with a g
 
 The trips API allows a user to query historical trip data.
 
-Endpoint: `/trips`  
-Method: `GET`  
-Response: See the [`trips` schema][trips-schema] for the expected format.
+Endpoint: `/trips`\
+Method: `GET`
+
+Response: See the [`trips` schema][trips-schema] for the expected format._
+Data: `{ "trips": [] }`, an array of objects with the following structure
 
 Data: `{ "trips": [] }`, an array of objects with the following structure
 
@@ -216,8 +218,9 @@ The status of the inventory of vehicles available for customer use.
 
 This API allows a user to query the historical availability for a system within a time range.
 
-Endpoint: `/status_changes`  
-Method: `GET`  
+Endpoint: `/status_changes`\
+Method: `GET`
+
 Response: See the [`status_changes` schema][sc-schema] for the expected format.
 
 Data: `{ "status_changes": [] }`, an array of objects with the following structure


### PR DESCRIPTION
We were using the undocumented two-trailing-spaces method to do line breaks in some places. Line breaks were missing in other places. Trailing spaces are not handled well in some editors, and Git likes to whine about trailing whitespace. Replace with backslashes and add missing. Backslashes are also non-standard and undocumented, unfortunately.