### PR TITLE
Fixing times to be more descriptive.

### DIFF
--- a/generate_schema/Pipfile
+++ b/generate_schema/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+jsonschema = "==3.0.0a2"
+requests = "==2.19.1"
+
+[dev-packages]
+
+[requires]
+python_version = "3.6"

--- a/generate_schema/provider/trips.json
+++ b/generate_schema/provider/trips.json
@@ -130,13 +130,22 @@
                   1529968782.421409
                 ]
               },
-              "end_time": {
-                "$id": "#/properties/data/properties/trips/items/properties/end_time",
+              "resevered_duration": {
+                "$id": "#/properties/data/properties/trips/items/properties/resevered_duration",
                 "type": "number",
-                "description": "The time the trip ended, expressed as a Unix Timestamp",
-                "default": 0.0,
+                "description": "The time that the device was reserved by the user, expressed as a integer number of seconds",
+                "default": 0,
                 "examples": [
-                  1531007628.3774529
+                  450
+                ]
+              },
+              "travel_duration": {
+                "$id": "#/properties/data/properties/trips/items/properties/resevered_duration",
+                "type": "number",
+                "description": "The time that the device was was moving, expressed as a integer number of seconds. Must always be less than reserved_duration",
+                "default": 0,
+                "examples": [
+                  450
                 ]
               },
               "parking_verification_url": {

--- a/provider/README.md
+++ b/provider/README.md
@@ -124,12 +124,12 @@ Data: `{ "trips": [] }`, an array of objects with the following structure
 | `vehicle_type` | Enum | Required | See [vehicle types](#vehicle-types) table |
 | `propulsion_type` | Enum[] | Required | Array of [propulsion types](#propulsion-types); allows multiple values |
 | `trip_id` | UUID | Required | A unique ID for each trip |
-| `trip_duration` | Integer | Required | Time, in Seconds |
+| `reserved_duration` | Integer | Required | Time, in Seconds, from start_time until the trip is complete |
+| `travel_duration` | Integer | Required | Time, in seconds, from when a vehicle is moved until trip is complete. The delta between `reserved_duration` and `travel_duration` represents the time it took a user from reservation to starting the device | 
 | `trip_distance` | Integer | Required | Trip Distance, in Meters |
 | `route` | GeoJSON `FeatureCollection` | Required | See [Routes](#routes) detail below |
 | `accuracy` | Integer | Required | The approximate level of accuracy, in meters, of `Points` within `route` |
 | `start_time` | [timestamp][ts] | Required | |
-| `end_time` | [timestamp][ts] | Required | |
 | `parking_verification_url` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking |
 | `standard_cost` | Integer | Optional | The cost, in cents, that it would cost to perform that trip in the standard operation of the System |
 | `actual_cost` | Integer | Optional | The actual cost, in cents, paid by the customer of the *mobility as a service* provider |

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -329,13 +329,22 @@
                   1529968782.421409
                 ]
               },
-              "end_time": {
-                "$id": "#/properties/data/properties/trips/items/properties/end_time",
+              "resevered_duration": {
+                "$id": "#/properties/data/properties/trips/items/properties/resevered_duration",
                 "type": "number",
-                "description": "The time the trip ended, expressed as a Unix Timestamp",
-                "default": 0.0,
+                "description": "The time that the device was reserved by the user, expressed as a integer number of seconds",
+                "default": 0,
                 "examples": [
-                  1531007628.3774529
+                  450
+                ]
+              },
+              "travel_duration": {
+                "$id": "#/properties/data/properties/trips/items/properties/resevered_duration",
+                "type": "number",
+                "description": "The time that the device was was moving, expressed as a integer number of seconds. Must always be less than reserved_duration",
+                "default": 0,
+                "examples": [
+                  450
                 ]
               },
               "parking_verification_url": {


### PR DESCRIPTION
In #52, we realized that trip_start, end and time aren't the best way to describe time. 

This pull request replaces trip_start, trip_duration, and trip_end with `start_time`, `reserved_duration` and `travel_duration` approach. 

this will be a breaking change. 