### PR TITLE
Update timestamp desc to  unix timestamp milliseconds

### DIFF
--- a/generate_schema/Pipfile
+++ b/generate_schema/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+jsonschema = "==3.0.0a2"
+requests = "==2.19.1"
+
+[dev-packages]
+
+[requires]
+python_version = "3.6"

--- a/generate_schema/common.json
+++ b/generate_schema/common.json
@@ -97,10 +97,10 @@
     },
     "timestamp": {
       "$id": "#/definitions/timestamp",
-      "title": "Integer seconds since Unix epoch",
+      "title": "Integer milliseconds since Unix epoch",
       "type": "number",
-      "multiple_of": 1.0, 
-      "minimum": 1483228800 
+      "multipleOf": 1.0, 
+      "minimum": 0 
     }
   }
 }

--- a/generate_schema/common.json
+++ b/generate_schema/common.json
@@ -97,9 +97,10 @@
     },
     "timestamp": {
       "$id": "#/definitions/timestamp",
-      "title": "Floating-point seconds since Unix epoch",
+      "title": "Integer seconds since Unix epoch",
       "type": "number",
-      "minimum": 0.0
+      "multiple_of": 1.0, 
+      "minimum": 1483228800 
     }
   }
 }

--- a/provider/README.md
+++ b/provider/README.md
@@ -83,7 +83,7 @@ represented as a GeoJSON [`Feature`](https://tools.ietf.org/html/rfc7946#section
 {
     "type": "Feature",
     "properties": {
-        "timestamp": 1529968782.421409
+        "timestamp": 1529968782421
     },
     "geometry": {
         "type": "Point",
@@ -99,8 +99,7 @@ represented as a GeoJSON [`Feature`](https://tools.ietf.org/html/rfc7946#section
 
 ### Timestamps
 
-References to `timestamp` imply floating-point seconds since [Unix epoch](https://en.wikipedia.org/wiki/Unix_time), such as
-the format returned by Python's [`time.time()`](https://docs.python.org/3/library/time.html#time.time) function.
+References to `timestamp` imply integer milliseconds since [Unix epoch](https://en.wikipedia.org/wiki/Unix_time). You can find the implementation of unix timestamp in milliseconds for your programming language [here](https://currentmillis.com/).
 
 [Top][toc]
 
@@ -183,7 +182,7 @@ Routes must include at least 2 points: the start point and end point. Additional
     "features": [{
         "type": "Feature",
         "properties": {
-            "timestamp": 1529968782.421409
+            "timestamp": 1529968782421
         },
         "geometry": {
             "type": "Point",
@@ -196,7 +195,7 @@ Routes must include at least 2 points: the start point and end point. Additional
     {
         "type": "Feature",
         "properties": {
-            "timestamp": 1531007628.3774529
+            "timestamp": 1531007628377
         },
         "geometry": {
             "type": "Point",

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -146,10 +146,10 @@
     },
     "timestamp": {
       "$id": "#/definitions/timestamp",
-      "title": "Integer seconds since Unix epoch",
+      "title": "Integer milliseconds since Unix epoch",
       "type": "number",
-      "multiple_of": 1.0,
-      "minimum": 1483228800
+      "multipleOf": 1.0,
+      "minimum": 0
     },
     "vehicle_type": {
       "$id": "#/definitions/vehicle_type",

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -47,12 +47,19 @@
       "properties": {
         "type": {
           "type": "string",
-          "emum": [
+          "enum": [
             "Feature"
           ]
         },
         "properties": {
-          "type": "object",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object"
+            }
+          ],
           "required": [
             "timestamp"
           ],
@@ -139,9 +146,10 @@
     },
     "timestamp": {
       "$id": "#/definitions/timestamp",
-      "title": "Floating-point seconds since Unix epoch",
+      "title": "Integer seconds since Unix epoch",
       "type": "number",
-      "minimum": 0.0
+      "multiple_of": 1.0,
+      "minimum": 1483228800
     },
     "vehicle_type": {
       "$id": "#/definitions/vehicle_type",

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -177,10 +177,10 @@
     },
     "timestamp": {
       "$id": "#/definitions/timestamp",
-      "title": "Integer seconds since Unix epoch",
+      "title": "Integer milliseconds since Unix epoch",
       "type": "number",
-      "multiple_of": 1.0,
-      "minimum": 1483228800
+      "multipleOf": 1.0,
+      "minimum": 0
     },
     "vehicle_type": {
       "$id": "#/definitions/vehicle_type",

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -47,12 +47,19 @@
       "properties": {
         "type": {
           "type": "string",
-          "emum": [
+          "enum": [
             "Feature"
           ]
         },
         "properties": {
-          "type": "object",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object"
+            }
+          ],
           "required": [
             "timestamp"
           ],
@@ -85,7 +92,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "emum": [
+          "enum": [
             "FeatureCollection"
           ]
         },
@@ -170,9 +177,10 @@
     },
     "timestamp": {
       "$id": "#/definitions/timestamp",
-      "title": "Floating-point seconds since Unix epoch",
+      "title": "Integer seconds since Unix epoch",
       "type": "number",
-      "minimum": 0.0
+      "multiple_of": 1.0,
+      "minimum": 1483228800
     },
     "vehicle_type": {
       "$id": "#/definitions/vehicle_type",


### PR DESCRIPTION
Per #104 and #133 all timestamp references are unix timestamp in milliseconds.

Provide link with different language implementations.

Also, update all provider sample data to be in unix timestamps in milliseconds.

No changes made to agency.

Addresses: #104 and #133