### PR TITLE
Suggestion to improve time based filtering

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -143,8 +143,8 @@ The trips API should allow querying trips with a combination of query parameters
 
 * `device_id`
 * `vehicle_id`
-* `start_time`: filters for trips where `start_time` occurs at or after the given time
-* `end_time`: filters for trips where `end_time` occurs at or before the given time
+* `min_end_time`: filters for trips where `end_time` occurs at or after the given time
+* `max_end_time`: filters for trips where `end_time` occurs before the given time
 * `bbox`
 
 All of these query params will use the *Type* listed above with the exception of `bbox`, which is the bounding-box.
@@ -246,7 +246,7 @@ Data: `{ "status_changes": [] }`, an array of objects with the following structu
 The status_changes API should allow querying status changes with a combination of query parameters.
 
 * `start_time`: filters for status changes where `event_time` occurs at or after the given time
-* `end_time`: filters for status changes where `event_time` occurs at or before the given time
+* `end_time`: filters for status changes where `event_time` occurs before the given time
 * `bbox`: filters for status changes where `event_location` is within defined bounding-box. The order is definied as: southwest longitude, southwest latitude, northeast longitude, northeast latitude (separated by commas). 
 
 Example:


### PR DESCRIPTION
Opening this PR as a conversation starter about a possibly cleaner way to specify time bounds, or at least learn more about the nature of the queries mobility providers will be receiving.

**Issue**
I imagine cities will be querying the `/trips` Mobility Provider APIs on a regular frequency to pull data for the hour.

**Query 1:** 1pm - 2pm
**Query 2:** 2pm - 3pm
**Query 3:** 3pm - 4pm

Currently, this would be done via the `start_time` and `end_time` query parameters. However, this will result in duplicate rows across responses. For example, a ride from 1:45-2:15pm will show up in both Query 1 and Query 2. If cities are ingesting this data, this will create more work to deduplicate.

**Suggestion**
- Replace `start_time` + `end_time` for `/trips` with `min_end_time` and `max_end_time`. The start time will be in inclusive, the max will be exclusive.
- Modify `/status_changes` `end_time` parameter to indicate that it is exclusive and not inclusive for that time.