### PR TITLE
Add OAauth client_credentials auth guidelines section

### DIFF
--- a/provider/auth.md
+++ b/provider/auth.md
@@ -1,13 +1,13 @@
 # Authorization
 
-MDS `providers` **SHALL** provide authorization for API endpoints via a bearer token based auth system. 
+MDS `providers` **SHALL** provide authorization for API endpoints via a bearer token based auth system.
 
 For example, the `Authorization` header sent as part of an HTTP request:
 
 ```
 GET /trips HTTP/1.1
 Host: api.provider.co
-Authorization: Bearer <token> 
+Authorization: Bearer <token>
 ```
 
 More info on how to document [Bearer Auth in swagger](https://swagger.io/docs/specification/authentication/bearer-authentication/)
@@ -23,3 +23,11 @@ JWTs provide a safe, secure way to verify the identity of an agency and provide 
 MDS `providers` **MAY** include any metadata in the JWT they wish that helps to route, log, permission, or debug agency requests, leaving their internal implementation flexible.
 
 JWT provides a helpful [debugger](https://jwt.io/#debugger) for testing your token and verifying security.
+
+## OAuth 2.0
+
+OAuth 2.0's `client_credentials` grant type (outlined in [RFC6749](https://tools.ietf.org/html/rfc6749#section-4.4)) is **RECOMMENDED** as the authentication and authorization scheme.
+
+OAuth 2.0 is an industry standard authorization framework with a variety of existing tooling. The `client_credentials` grant type facilitates generation of tokens that can be used for access by agencies and distributed to data partners.
+
+If an MDS `provider` implements this auth scheme, it **MAY** choose to specify token scopes that define access parameters like allowable time ranges. These guidelines **SHOULD** be encoded into the returned token in a parseable way.


### PR DESCRIPTION
In previous discussions (linked below) about authenticating MDS requests, there was a preference for not prescribing a specific authentication method. While there are benefits to the MDS protocol definition remaining process-agnostic and not prescriptive, the immediate drawbacks are that cities and data partners struggle to maintain multiple authentication schemes and mobility providers do not have alignment on security best practices for authorization to access MDS data.

In this PR, I propose specifying the OAuth2.0 `client_credentials` grant type as a way to alleviate this. In this auth scheme, a client secret is given by a mobility provider to a city, who can then use it to generate access tokens via the provider’s OAuth2.0 service in a repeatable, documented way. These tokens are commonly supplied in JWT format by many OAuth frameworks, so there is tooling around permissions, identity, and expiry built into the format already, easing the load on providers.

Another useful feature of OAuth grants is token scopes, which can be used for access control for third party applications. E.g. if LA is working with a third party data ingestion platform, using this grant type they can request a token in a (for example) `PARTNER` scope with certain permissions, date boundaries, and expiry/refresh configuration. This token can then be used by the partner without the mobility provider extending to them access to their entire historical MDS API. This may be useful for scoped introduction of new MDS endpoints, as well.

If reasonable/desirable, I can flesh out some suggested scopes and token parameters.

Related discussions:
- https://github.com/CityOfLosAngeles/mobility-data-specification/pull/81 
- https://github.com/CityOfLosAngeles/mobility-data-specification/issues/121