### PR TITLE
Allowing for null links properties

### DIFF
--- a/generate_schema/common.json
+++ b/generate_schema/common.json
@@ -50,42 +50,50 @@
     "links": {
       "$id": "#/definitions/links",
       "type": "object",
+      "required":[
+        "next"
+      ],
       "properties": {
         "first": {
           "$id": "#/definitions/links/first",
-          "type": "string",
+          "type": [
+            "null",
+            "string"
+          ],
           "title": "The URL to the first page of data",
           "examples": [
             "https://data.provider.co/trips/first"
           ],
-          "format": "uri",
-          "pattern": "^(.*)$"
+          "format": "uri"
         },
         "last": {
           "$id": "#/definitions/links/last",
-          "type": "string",
+          "type": [
+            "null",
+            "string"
+          ],
           "title": "The URL to the last page of data",
           "examples": [
             "https://data.provider.co/trips/last"
           ],
-          "format": "uri",
-          "pattern": "^(.*)$"
+          "format": "uri"
         },
         "prev": {
           "$id": "#/definitions/links/prev",
-          "type": "string",
+          "type": [
+            "null",
+            "string"
+          ],
           "title": "The URL to the previous page of data",
           "examples": [
             "https://data.provider.co/trips/prev"
           ],
-          "format": "uri",
-          "pattern": "^(.*)$"
+          "format": "uri"
         },
         "next": {
           "$id": "#/definitions/links/next",
           "type": "string",
           "title": "The URL to the next page of data",
-          "default": "",
           "examples": [
             "https://data.provider.co/trips/next"
           ],

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -76,42 +76,50 @@
     "links": {
       "$id": "#/definitions/links",
       "type": "object",
+      "required": [
+        "next"
+      ],
       "properties": {
         "first": {
           "$id": "#/definitions/links/first",
-          "type": "string",
+          "type": [
+            "null",
+            "string"
+          ],
           "title": "The URL to the first page of data",
           "examples": [
             "https://data.provider.co/trips/first"
           ],
-          "format": "uri",
-          "pattern": "^(.*)$"
+          "format": "uri"
         },
         "last": {
           "$id": "#/definitions/links/last",
-          "type": "string",
+          "type": [
+            "null",
+            "string"
+          ],
           "title": "The URL to the last page of data",
           "examples": [
             "https://data.provider.co/trips/last"
           ],
-          "format": "uri",
-          "pattern": "^(.*)$"
+          "format": "uri"
         },
         "prev": {
           "$id": "#/definitions/links/prev",
-          "type": "string",
+          "type": [
+            "null",
+            "string"
+          ],
           "title": "The URL to the previous page of data",
           "examples": [
             "https://data.provider.co/trips/prev"
           ],
-          "format": "uri",
-          "pattern": "^(.*)$"
+          "format": "uri"
         },
         "next": {
           "$id": "#/definitions/links/next",
           "type": "string",
           "title": "The URL to the next page of data",
-          "default": "",
           "examples": [
             "https://data.provider.co/trips/next"
           ],

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -107,42 +107,50 @@
     "links": {
       "$id": "#/definitions/links",
       "type": "object",
+      "required": [
+        "next"
+      ],
       "properties": {
         "first": {
           "$id": "#/definitions/links/first",
-          "type": "string",
+          "type": [
+            "null",
+            "string"
+          ],
           "title": "The URL to the first page of data",
           "examples": [
             "https://data.provider.co/trips/first"
           ],
-          "format": "uri",
-          "pattern": "^(.*)$"
+          "format": "uri"
         },
         "last": {
           "$id": "#/definitions/links/last",
-          "type": "string",
+          "type": [
+            "null",
+            "string"
+          ],
           "title": "The URL to the last page of data",
           "examples": [
             "https://data.provider.co/trips/last"
           ],
-          "format": "uri",
-          "pattern": "^(.*)$"
+          "format": "uri"
         },
         "prev": {
           "$id": "#/definitions/links/prev",
-          "type": "string",
+          "type": [
+            "null",
+            "string"
+          ],
           "title": "The URL to the previous page of data",
           "examples": [
             "https://data.provider.co/trips/prev"
           ],
-          "format": "uri",
-          "pattern": "^(.*)$"
+          "format": "uri"
         },
         "next": {
           "$id": "#/definitions/links/next",
           "type": "string",
           "title": "The URL to the next page of data",
-          "default": "",
           "examples": [
             "https://data.provider.co/trips/next"
           ],


### PR DESCRIPTION
`links` itself is still optional, this just clarifies that the only required `links` property is `next`.

