### PR TITLE
A more restful Agency API

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -226,9 +226,8 @@ Response:
 
 For `vehicle_type`, options are:
 
-* `bike`
+* `bicycle`
 * `scooter`
-* `recumbent`
 
 ### propulsion_type
 
@@ -236,6 +235,7 @@ For `propulsion_type`, options are:
 
 * `human`
 * `electric`
+* `electric_assist`
 * `combustion`
 
 ### reason_code


### PR DESCRIPTION
A proposal for a more RESTful Agency API.

This adresses issues https://github.com/CityOfLosAngeles/mobility-data-specification/pull/116 and https://github.com/CityOfLosAngeles/mobility-data-specification/issues/63.

All fields are kept, this is just some moving around on endpoints and HTTP methods.
The `provider_id` and `unique_id` fields are systematically in the path (endpoint URL).
I took the liberty to align `propulsion_type` and `vehicle_type` on the provider API definitions in a separated commit.

About responses, I treated this part in a separated PR : https://github.com/CityOfLosAngeles/mobility-data-specification/pull/156 .

Note that this PR highlights a possible confusion between the `vehicle_id` field for vehicle registration (containing the VIN) and the `vehicle_id` field for starting a new trip, supposed to contain the unique vehicle ID used at registration (not the VIN). I wanted to avoid renaming fields as much as possible in the PR, but renaming at least the VIN to something else (ie. `identification_number`) could be more clear.

Comments and insights are welcome.