### PR TITLE
Agency schema

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -83,7 +83,7 @@ Body:
 | `timestamp` | Unix Timestamp | Required | Date/time that event occurred. Based on GPS clock. |
 | `location` | Point | Required | Location at the time of status change in WGS 84 (EPSG:4326) standard GPS projection  |
 | `event_type` | Enum | Required | [Event Type](#event_type) for status change.  |
-| `reason_code` | Enum | Required | [Reason](#reason_code) for status change.  |
+| `event_type_reason` | Enum | Required | [Reason](#event_type) for status change.  |
 | `battery_pct` | Float | Require if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 
 Response:
@@ -106,7 +106,7 @@ Body:
 | `provider_id` | String | Required | Issued by city |
 | `vehicle_id` | String | Required | Provided by the Vehicle Registration API |
 | `timestamp` | Unix Timestamp | Required | Date/time that event occurred. Based on GPS clock. |
-| `location` | Point | Required | Location at the time of status change in WGS 84 (EPSG:4326) standard GPS projection  |
+| `location` | GeoJSON [Point Feature](#geographic-data) | Required | Location at the time of status change in WGS 84 (EPSG:4326) standard GPS projection  |
 | `accuracy` | Integer | Required | The approximate level of accuracy, in meters, represented by start_point and end_point. |
 | `battery_pct_start` | Float | Require if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 
@@ -128,7 +128,7 @@ Body:
 | ----- | ---- | ----------------- | ----- |
 | `trip_id` | UUID | Required | See [start_trip](#start_trip) |
 | `timestamp` | Unix Timestamp | Required | Date/time that event occurred. Based on GPS clock. |
-| `location` | Point | Required | Location at the time of status change in WGS 84 (EPSG:4326) standard GPS projection  |
+| `location` | GeoJSON [Point Feature](#geographic-data) | Required | Location at the time of status change in WGS 84 (EPSG:4326) standard GPS projection  |
 | `accuracy` | Integer | Required | The approximate level of accuracy, in meters, represented by start_point and end_point. |
 | `battery_pct_end` | Float | Require if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 
@@ -157,7 +157,7 @@ Response:
 
 ### Route
 
-To represent a route, MDS provider APIs should create a GeoJSON Feature Collection where ever observed point in the route, plus a time stamp, should be included. The representation needed is below.
+To represent a route, MDS provider APIs should create a GeoJSON Feature Collection where every observed point in the route, plus a time stamp, should be included. The representation needed is below.
 
 The route must include at least 2 points, a start point and end point. Additionally, it must include all possible GPS samples collected by a provider. All points must be in WGS 84 (EPSG:4326) standard GPS projection
 
@@ -229,6 +229,31 @@ Response:
 | preferred_pick_up | Areas where users are encouraged to pick up devices |
 | preferred_drop_off | Areas where users are encouraged to drop off devices |
 
+
+
+### Geographic Data
+
+References to geographic datatypes (Point, MultiPolygon, etc.) imply coordinates encoded in the [WGS 84 (EPSG:4326)](https://en.wikipedia.org/wiki/World_Geodetic_System) standard GPS projection expressed as [Decimal Degrees](https://en.wikipedia.org/wiki/Decimal_degrees).
+
+Whenever an individual location coordinate measurement is presented, it must be
+represented as a GeoJSON [`Feature`](https://tools.ietf.org/html/rfc7946#section-3.2) object with a corresponding [`timestamp`][ts] property and [`Point`](https://tools.ietf.org/html/rfc7946#section-3.1.2) geometry:
+
+```json
+{
+    "type": "Feature",
+    "properties": {
+        "timestamp": 1529968782.421409
+    },
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            -118.46710503101347,
+            33.9909333514159
+        ]
+    }
+}
+```
+
 ### Event Types
 
 | event_type | event_type_description |  reason | reason_description  |
@@ -254,7 +279,6 @@ For `vehicle_type`, options are:
 
 * `bike`
 * `scooter`
-* `recumbent`
 
 ### propulsion_type
 
@@ -262,6 +286,7 @@ For `propulsion_type`, options are:
 
 * `human`
 * `electric`
+* `electric_assist`
 * `combustion`
 
 ### reason_code

--- a/agency/deregister_vehicle.json
+++ b/agency/deregister_vehicle.json
@@ -3,7 +3,29 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "The MDS Agency Schema, deregister_vehicle payload",
   "type": "object",
-  "definitions": {},
+  "definitions": {
+    "uuid": {
+      "$id": "#/definitions/uuid",
+      "type": "string",
+      "title": "A UUID 4 used to uniquely identifty an object",
+      "default": "",
+      "examples": [
+        "3c9604d6-b5ee-11e8-96f8-529269fb1459"
+      ],
+      "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+    },
+    "battery_pct": {
+      "$id": "#/definitions/battery_pct",
+      "type": "number",
+      "description": "Percent charge of device battery, expressed between 0 and 1",
+      "default": 0.0,
+      "examples": [
+        0.89
+      ],
+      "minimum": 0,
+      "maximum": 1
+    }
+  },
   "required": [
     "unique_id",
     "device_id",

--- a/agency/end_trip.json
+++ b/agency/end_trip.json
@@ -35,6 +35,52 @@
         }
       }
     },
+    "MDS_Feature_Point": {
+      "$id": "#/definitions/MDS_Feature_Point",
+      "title": "MDS GeoJSON Feature Point",
+      "type": "object",
+      "required": [
+        "type",
+        "properties",
+        "geometry"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Feature"
+          ]
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "required": [
+            "timestamp"
+          ],
+          "properties": {
+            "timestamp": {
+              "$ref": "#/definitions/timestamp"
+            }
+          }
+        },
+        "geometry": {
+          "$ref": "#/definitions/Point"
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
     "uuid": {
       "$id": "#/definitions/uuid",
       "type": "string",
@@ -91,7 +137,7 @@
     "location": {
       "$id": "#/properties/location",
       "description": "The GPS coordinates of where the event occurred",
-      "$ref": "#/definitions/Point"
+      "$ref": "#/definitions/MDS_Feature_Point"
     },
     "timestamp": {
       "$id": "#/properties/location",

--- a/agency/end_trip.json
+++ b/agency/end_trip.json
@@ -1,0 +1,102 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/end_trip.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, end_trip payload",
+  "type": "object",
+  "definitions": {
+    "Point": {
+      "$id": "#/definitions/Point",
+      "title": "GeoJSON Point",
+      "type": "object",
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Point"
+          ]
+        },
+        "coordinates": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "number"
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "uuid": {
+      "$id": "#/definitions/uuid",
+      "type": "string",
+      "title": "A UUID 4 used to uniquely identifty an object",
+      "default": "",
+      "examples": [
+        "3c9604d6-b5ee-11e8-96f8-529269fb1459"
+      ],
+      "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+    },
+    "battery_pct": {
+      "$id": "#/definitions/battery_pct",
+      "type": "number",
+      "description": "Percent charge of device battery, expressed between 0 and 1",
+      "default": 0.0,
+      "examples": [
+        0.89
+      ],
+      "minimum": 0,
+      "maximum": 1
+    },
+    "timestamp": {
+      "$id": "#/definitions/timestamp",
+      "title": "Floating-point seconds since Unix epoch",
+      "type": "number",
+      "minimum": 0.0
+    }
+  },
+  "required": [
+    "trip_id",
+    "timestamp",
+    "location",
+    "accuracy"
+  ],
+  "properties": {
+    "trip_id": {
+      "$id": "#/properties/trip_id",
+      "description": "The UUID for the trip.",
+      "$ref": "#/definitions/uuid"
+    },
+    "battery_pct_end": {
+      "$id": "#/properties/battery_pct_end",
+      "$ref": "#/definitions/battery_pct"
+    },
+    "accuracy": {
+      "$id": "#/properties/accuracy",
+      "type": "integer",
+      "title": "The approximate level of accuracy, in meters, of Points within route",
+      "default": 0,
+      "examples": [
+        15
+      ]
+    },
+    "location": {
+      "$id": "#/properties/location",
+      "description": "The GPS coordinates of where the event occurred",
+      "$ref": "#/definitions/Point"
+    },
+    "timestamp": {
+      "$id": "#/properties/location",
+      "$ref": "#/definitions/timestamp"
+    }
+  },
+  "additionalProperties": false
+}

--- a/agency/register_vehicle.json
+++ b/agency/register_vehicle.json
@@ -1,0 +1,113 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/register_vehicle.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, register_vehicle payload",
+  "type": "object",
+  "definitions": {
+    "propulsion_type": {
+      "$id": "#/definitions/propulsion_type",
+      "type": "array",
+      "description": "The type of propulsion; allows multiple values",
+      "items": {
+        "type": "string",
+        "enum": [
+          "combustion",
+          "electric",
+          "electric_assist",
+          "human"
+        ]
+      },
+      "minItems": 1
+    },
+    "vehicle_type": {
+      "$id": "#/definitions/vehicle_type",
+      "type": "string",
+      "description": "The type of vehicle",
+      "enum": [
+        "bicycle",
+        "scooter"
+      ]
+    },
+    "uuid": {
+      "$id": "#/definitions/uuid",
+      "type": "string",
+      "title": "A UUID 4 used to uniquely identifty an object",
+      "default": "",
+      "examples": [
+        "3c9604d6-b5ee-11e8-96f8-529269fb1459"
+      ],
+      "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+    }
+  },
+  "required": [
+    "unique_id",
+    "provider_id",
+    "vehicle_id",
+    "vehicle_type",
+    "vehicle_year",
+    "vehicle_mfgr",
+    "vehicle_model"
+  ],
+  "properties": {
+    "unique_id": {
+      "$id": "#/properties/unique_id",
+      "description": "The UUID for the vehicle, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "provider_id": {
+      "$id": "#/properties/provider_id",
+      "description": "The UUID for the Provider, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "vehicle_id": {
+      "$id": "#/properties/vehicle_id",
+      "type": "string",
+      "description": "The Vehicle Identification Number visible on the vehicle itself",
+      "default": "",
+      "examples": [
+        "ABC123"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "vehicle_type": {
+      "$id": "#/properties/vehicle_type",
+      "$ref": "#/definitions/vehicle_type",
+      "description": "The type of vehicle"
+    },
+    "propulsion_type": {
+      "$id": "#/properties/propulsion_type",
+      "description": "The type of propulsion; allows multiple values",
+      "$ref": "#/definitions/propulsion_type"
+    },
+    "vehicle_year": {
+      "$id": "#/properties/vehicle_id",
+      "type": "integer",
+      "description": "The year the vehicle was manufactured",
+      "default": 1970,
+      "examples": [
+        2018
+      ]
+    },
+    "vehicle_mfgr": {
+      "$id": "#/properties/vehicle_mfgr",
+      "type": "string",
+      "description": "The vehicle manufacturer",
+      "default": "",
+      "examples": [
+        "ABC123"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "vehicle_model": {
+      "$id": "#/properties/vehicle_model",
+      "type": "string",
+      "description": "The vehicle model",
+      "default": "",
+      "examples": [
+        "ABC123"
+      ],
+      "pattern": "^(.*)$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/agency/service_areas.json
+++ b/agency/service_areas.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/service_areas.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, service_areas payload",
+  "type": "object",
+  "definitions": {
+    "uuid": {
+      "$id": "#/definitions/uuid",
+      "type": "string",
+      "title": "A UUID 4 used to uniquely identifty an object",
+      "default": "",
+      "examples": [
+        "3c9604d6-b5ee-11e8-96f8-529269fb1459"
+      ],
+      "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+    }
+  },
+  "required": [
+    "provider_id"
+  ],
+  "properties": {
+    "provider_id": {
+      "$id": "#/properties/provider_id",
+      "description": "The UUID for the Provider, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "service_area_id": {
+      "$id": "#/properties/service_area_id",
+      "description": "An optional UUID for a service area to check for the provider",
+      "$ref": "#/definitions/uuid"
+    }
+  },
+  "additionalProperties": false
+}

--- a/agency/start_trip.json
+++ b/agency/start_trip.json
@@ -35,6 +35,52 @@
         }
       }
     },
+    "MDS_Feature_Point": {
+      "$id": "#/definitions/MDS_Feature_Point",
+      "title": "MDS GeoJSON Feature Point",
+      "type": "object",
+      "required": [
+        "type",
+        "properties",
+        "geometry"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Feature"
+          ]
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "required": [
+            "timestamp"
+          ],
+          "properties": {
+            "timestamp": {
+              "$ref": "#/definitions/timestamp"
+            }
+          }
+        },
+        "geometry": {
+          "$ref": "#/definitions/Point"
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
     "uuid": {
       "$id": "#/definitions/uuid",
       "type": "string",
@@ -108,7 +154,7 @@
     "location": {
       "$id": "#/properties/location",
       "description": "The GPS coordinates of where the event occurred",
-      "$ref": "#/definitions/Point"
+      "$ref": "#/definitions/MDS_Feature_Point"
     },
     "timestamp": {
       "$id": "#/properties/location",

--- a/agency/start_trip.json
+++ b/agency/start_trip.json
@@ -1,0 +1,119 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/start_trip.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, start_trip payload",
+  "type": "object",
+  "definitions": {
+    "Point": {
+      "$id": "#/definitions/Point",
+      "title": "GeoJSON Point",
+      "type": "object",
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Point"
+          ]
+        },
+        "coordinates": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "number"
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "uuid": {
+      "$id": "#/definitions/uuid",
+      "type": "string",
+      "title": "A UUID 4 used to uniquely identifty an object",
+      "default": "",
+      "examples": [
+        "3c9604d6-b5ee-11e8-96f8-529269fb1459"
+      ],
+      "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+    },
+    "battery_pct": {
+      "$id": "#/definitions/battery_pct",
+      "type": "number",
+      "description": "Percent charge of device battery, expressed between 0 and 1",
+      "default": 0.0,
+      "examples": [
+        0.89
+      ],
+      "minimum": 0,
+      "maximum": 1
+    },
+    "timestamp": {
+      "$id": "#/definitions/timestamp",
+      "title": "Floating-point seconds since Unix epoch",
+      "type": "number",
+      "minimum": 0.0
+    }
+  },
+  "required": [
+    "unique_id",
+    "provider_id",
+    "vehicle_id",
+    "timestamp",
+    "location",
+    "accuracy"
+  ],
+  "properties": {
+    "unique_id": {
+      "$id": "#/properties/unique_id",
+      "description": "The UUID for the vehicle, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "provider_id": {
+      "$id": "#/properties/provider_id",
+      "description": "The UUID for the Provider, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "vehicle_id": {
+      "$id": "#/properties/vehicle_id",
+      "type": "string",
+      "description": "The Vehicle Identification Number visible on the vehicle itself",
+      "default": "",
+      "examples": [
+        "ABC123"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "battery_pct_start": {
+      "$id": "#/properties/battery_pct_start",
+      "$ref": "#/definitions/battery_pct"
+    },
+    "accuracy": {
+      "$id": "#/properties/accuracy",
+      "type": "integer",
+      "title": "The approximate level of accuracy, in meters, of Points within route",
+      "default": 0,
+      "examples": [
+        15
+      ]
+    },
+    "location": {
+      "$id": "#/properties/location",
+      "description": "The GPS coordinates of where the event occurred",
+      "$ref": "#/definitions/Point"
+    },
+    "timestamp": {
+      "$id": "#/properties/location",
+      "$ref": "#/definitions/timestamp"
+    }
+  },
+  "additionalProperties": false
+}

--- a/agency/update_trip_telemetry.json
+++ b/agency/update_trip_telemetry.json
@@ -1,0 +1,86 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/update_trip_telemetry.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, update_trip_telemetry payload",
+  "type": "object",
+  "definitions": {
+    "MDS_FeatureCollection_Route": {
+      "$id": "#/definitions/MDS_FeatureCollection_Route",
+      "title": "MDS GeoJSON FeatureCollection Route",
+      "type": "object",
+      "required": [
+        "type",
+        "features"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "FeatureCollection"
+          ]
+        },
+        "features": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MDS_Feature_Point"
+          },
+          "minItems": 2
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "uuid": {
+      "$id": "#/definitions/uuid",
+      "type": "string",
+      "title": "A UUID 4 used to uniquely identifty an object",
+      "default": "",
+      "examples": [
+        "3c9604d6-b5ee-11e8-96f8-529269fb1459"
+      ],
+      "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+    },
+    "timestamp": {
+      "$id": "#/definitions/timestamp",
+      "title": "Floating-point seconds since Unix epoch",
+      "type": "number",
+      "minimum": 0.0
+    }
+  },
+  "required": [
+    "trip_id",
+    "timestamp",
+    "route",
+    "accuracy"
+  ],
+  "properties": {
+    "trip_id": {
+      "$id": "#/properties/trip_id",
+      "description": "The UUID for the trip.",
+      "$ref": "#/definitions/uuid"
+    },
+    "accuracy": {
+      "$id": "#/properties/accuracy",
+      "type": "integer",
+      "title": "The approximate level of accuracy, in meters, of Points within route",
+      "default": 0,
+      "examples": [
+        15
+      ]
+    },
+    "route": {
+      "$id": "#/properties/location",
+      "$ref": "#/definitions/MDS_FeatureCollection_Route"
+    },
+    "timestamp": {
+      "$id": "#/properties/location",
+      "$ref": "#/definitions/timestamp"
+    }
+  },
+  "additionalProperties": false
+}

--- a/agency/update_trip_telemetry.json
+++ b/agency/update_trip_telemetry.json
@@ -4,6 +4,83 @@
   "title": "The MDS Agency Schema, update_trip_telemetry payload",
   "type": "object",
   "definitions": {
+    "Point": {
+      "$id": "#/definitions/Point",
+      "title": "GeoJSON Point",
+      "type": "object",
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Point"
+          ]
+        },
+        "coordinates": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "number"
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "MDS_Feature_Point": {
+      "$id": "#/definitions/MDS_Feature_Point",
+      "title": "MDS GeoJSON Feature Point",
+      "type": "object",
+      "required": [
+        "type",
+        "properties",
+        "geometry"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Feature"
+          ]
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "required": [
+            "timestamp"
+          ],
+          "properties": {
+            "timestamp": {
+              "$ref": "#/definitions/timestamp"
+            }
+          }
+        },
+        "geometry": {
+          "$ref": "#/definitions/Point"
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
     "MDS_FeatureCollection_Route": {
       "$id": "#/definitions/MDS_FeatureCollection_Route",
       "title": "MDS GeoJSON FeatureCollection Route",

--- a/agency/update_vehicle_status.json
+++ b/agency/update_vehicle_status.json
@@ -1,0 +1,199 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/update_vehicle_status.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, update_vehicle_status payload",
+  "type": "object",
+  "definitions": {
+    "Point": {
+      "$id": "#/definitions/Point",
+      "title": "GeoJSON Point",
+      "type": "object",
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Point"
+          ]
+        },
+        "coordinates": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "number"
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "uuid": {
+      "$id": "#/definitions/uuid",
+      "type": "string",
+      "title": "A UUID 4 used to uniquely identifty an object",
+      "default": "",
+      "examples": [
+        "3c9604d6-b5ee-11e8-96f8-529269fb1459"
+      ],
+      "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+    },
+    "battery_pct": {
+      "$id": "#/definitions/battery_pct",
+      "type": "number",
+      "description": "Percent charge of device battery, expressed between 0 and 1",
+      "default": 0.0,
+      "examples": [
+        0.89
+      ],
+      "minimum": 0,
+      "maximum": 1
+    },
+    "timestamp": {
+      "$id": "#/definitions/timestamp",
+      "title": "Floating-point seconds since Unix epoch",
+      "type": "number",
+      "minimum": 0.0
+    },
+    "available_event": {
+      "$id": "#/definitions/available_event",
+      "type": "object",
+      "description": "An event type describing a vehicle becoming available",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "The type of the event",
+          "enum": [
+            "available"
+          ]
+        },
+        "event_type_reason": {
+          "type": "string",
+          "description": "The reason for the event",
+          "enum": [
+            "service_start",
+            "user_drop_off",
+            "rebalance_drop_off",
+            "maintenance_drop_off"
+          ]
+        }
+      }
+    },
+    "unavailable_event": {
+      "$id": "#/definitions/unavailable_event",
+      "type": "object",
+      "description": "An event type describing a vehicle becoming unavailable",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "The type of the event",
+          "enum": [
+            "unavailable"
+          ]
+        },
+        "event_type_reason": {
+          "type": "string",
+          "description": "The reason for the event",
+          "enum": [
+            "default",
+            "low_battery",
+            "maintenance"
+          ]
+        }
+      }
+    },
+    "reserved_event": {
+      "$id": "#/definitions/reserved_event",
+      "type": "object",
+      "description": "An event type describing a vehicle becoming reserved",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "The type of the event",
+          "enum": [
+            "reserved"
+          ]
+        },
+        "event_type_reason": {
+          "type": "string",
+          "description": "The reason for the event",
+          "enum": [
+            "user_pick_up"
+          ]
+        }
+      }
+    },
+    "removed_event": {
+      "$id": "#/definitions/removed_event",
+      "type": "object",
+      "description": "An event type describing a vehicle becoming removed",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "The type of the event",
+          "enum": [
+            "removed"
+          ]
+        },
+        "event_type_reason": {
+          "type": "string",
+          "description": "The reason for the event",
+          "enum": [
+            "service_end",
+            "rebalance_pick_up",
+            "maintenance_pick_up"
+          ]
+        }
+      }
+    }
+  },
+  "required": [
+    "unique_id",
+    "timestamp",
+    "location",
+    "event_type",
+    "event_type_reason"
+  ],
+  "oneOf": [
+    {
+      "$ref": "#definitions/available_event"
+    },
+    {
+      "$ref": "#definitions/unavailable_event"
+    },
+    {
+      "$ref": "#definitions/reserved_event"
+    },
+    {
+      "$ref": "#definitions/removed_event"
+    }
+  ],
+  "properties": {
+    "unique_id": {
+      "$id": "#/properties/unique_id",
+      "description": "The UUID for the vehicle, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "battery_pct": {
+      "$id": "#/properties/battery_pct",
+      "$ref": "#/definitions/battery_pct"
+    },
+    "location": {
+      "$id": "#/properties/location",
+      "description": "The GPS coordinates of where the event occurred",
+      "$ref": "#/definitions/Point"
+    },
+    "timestamp": {
+      "$id": "#/properties/location",
+      "$ref": "#/definitions/timestamp"
+    }
+  },
+  "additionalProperties": false
+}

--- a/agency/update_vehicle_status.json
+++ b/agency/update_vehicle_status.json
@@ -163,16 +163,16 @@
   ],
   "oneOf": [
     {
-      "$ref": "#definitions/available_event"
+      "$ref": "#/definitions/available_event"
     },
     {
-      "$ref": "#definitions/unavailable_event"
+      "$ref": "#/definitions/unavailable_event"
     },
     {
-      "$ref": "#definitions/reserved_event"
+      "$ref": "#/definitions/reserved_event"
     },
     {
-      "$ref": "#definitions/removed_event"
+      "$ref": "#/definitions/removed_event"
     }
   ],
   "properties": {

--- a/agency/update_vehicle_status.json
+++ b/agency/update_vehicle_status.json
@@ -35,6 +35,52 @@
         }
       }
     },
+    "MDS_Feature_Point": {
+      "$id": "#/definitions/MDS_Feature_Point",
+      "title": "MDS GeoJSON Feature Point",
+      "type": "object",
+      "required": [
+        "type",
+        "properties",
+        "geometry"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Feature"
+          ]
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "required": [
+            "timestamp"
+          ],
+          "properties": {
+            "timestamp": {
+              "$ref": "#/definitions/timestamp"
+            }
+          }
+        },
+        "geometry": {
+          "$ref": "#/definitions/Point"
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
     "uuid": {
       "$id": "#/definitions/uuid",
       "type": "string",
@@ -188,7 +234,7 @@
     "location": {
       "$id": "#/properties/location",
       "description": "The GPS coordinates of where the event occurred",
-      "$ref": "#/definitions/Point"
+      "$ref": "#/definitions/MDS_Feature_Point"
     },
     "timestamp": {
       "$id": "#/properties/location",

--- a/generate_schema/agency/deregister_vehicle.json
+++ b/generate_schema/agency/deregister_vehicle.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/deregister_vehicle.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, deregister_vehicle payload",
+  "type": "object",
+  "definitions": {},
+  "required": [
+    "unique_id",
+    "device_id",
+    "reason_code"
+  ],
+  "properties": {
+    "unique_id": {
+      "$id": "#/properties/unique_id",
+      "description": "The UUID for the vehicle, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "device_id": {
+      "$id": "#/properties/device_id",
+      "$ref": "#/definitions/uuid",
+      "description": "A unique device ID in UUID format"
+    }
+  },
+  "additionalProperties": false
+}

--- a/generate_schema/agency/end_trip.json
+++ b/generate_schema/agency/end_trip.json
@@ -1,0 +1,43 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/end_trip.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, end_trip payload",
+  "type": "object",
+  "definitions": {},
+  "required": [
+    "trip_id",
+    "timestamp",
+    "location",
+    "accuracy"
+  ],
+  "properties": {
+    "trip_id": {
+      "$id": "#/properties/trip_id",
+      "description": "The UUID for the trip.",
+      "$ref": "#/definitions/uuid"
+    },
+    "battery_pct_end": {
+      "$id": "#/properties/battery_pct_end",
+      "$ref": "#/definitions/battery_pct"
+    },
+    "accuracy": {
+      "$id": "#/properties/accuracy",
+      "type": "integer",
+      "title": "The approximate level of accuracy, in meters, of Points within route",
+      "default": 0,
+      "examples": [
+        15
+      ]
+    },
+    "location": {
+      "$id": "#/properties/location",
+      "description": "The GPS coordinates of where the event occurred",
+      "$ref": "#/definitions/Point"
+    },
+    "timestamp": {
+      "$id": "#/properties/location",
+      "$ref": "#/definitions/timestamp"
+    }
+  },
+  "additionalProperties": false
+}

--- a/generate_schema/agency/end_trip.json
+++ b/generate_schema/agency/end_trip.json
@@ -32,7 +32,7 @@
     "location": {
       "$id": "#/properties/location",
       "description": "The GPS coordinates of where the event occurred",
-      "$ref": "#/definitions/Point"
+      "$ref": "#/definitions/MDS_Feature_Point"
     },
     "timestamp": {
       "$id": "#/properties/location",

--- a/generate_schema/agency/register_vehicle.json
+++ b/generate_schema/agency/register_vehicle.json
@@ -1,0 +1,78 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/register_vehicle.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, register_vehicle payload",
+  "type": "object",
+  "definitions": {},
+  "required": [
+    "unique_id",
+    "provider_id",
+    "vehicle_id",
+    "vehicle_type",
+    "vehicle_year",
+    "vehicle_mfgr",
+    "vehicle_model"
+  ],
+  "properties": {
+    "unique_id": {
+      "$id": "#/properties/unique_id",
+      "description": "The UUID for the vehicle, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "provider_id": {
+      "$id": "#/properties/provider_id",
+      "description": "The UUID for the Provider, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "vehicle_id": {
+      "$id": "#/properties/vehicle_id",
+      "type": "string",
+      "description": "The Vehicle Identification Number visible on the vehicle itself",
+      "default": "",
+      "examples": [
+        "ABC123"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "vehicle_type": {
+      "$id": "#/properties/vehicle_type",
+      "$ref": "#/definitions/vehicle_type",
+      "description": "The type of vehicle"
+    },
+    "propulsion_type": {
+      "$id": "#/properties/propulsion_type",
+      "description": "The type of propulsion; allows multiple values",
+      "$ref": "#/definitions/propulsion_type"
+    },
+    "vehicle_year": {
+      "$id": "#/properties/vehicle_id",
+      "type": "integer",
+      "description": "The year the vehicle was manufactured",
+      "default": 1970,
+      "examples": [
+        2018
+      ]
+    },
+    "vehicle_mfgr": {
+      "$id": "#/properties/vehicle_mfgr",
+      "type": "string",
+      "description": "The vehicle manufacturer",
+      "default": "",
+      "examples": [
+        "ABC123"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "vehicle_model": {
+      "$id": "#/properties/vehicle_model",
+      "type": "string",
+      "description": "The vehicle model",
+      "default": "",
+      "examples": [
+        "ABC123"
+      ],
+      "pattern": "^(.*)$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/generate_schema/agency/service_areas.json
+++ b/generate_schema/agency/service_areas.json
@@ -1,0 +1,23 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/service_areas.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, service_areas payload",
+  "type": "object",
+  "definitions": {},
+  "required": [
+    "provider_id"
+  ],
+  "properties": {
+    "provider_id": {
+      "$id": "#/properties/provider_id",
+      "description": "The UUID for the Provider, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "service_area_id": {
+      "$id": "#/properties/service_area_id",
+      "description": "An optional UUID for a service area to check for the provider",
+      "$ref": "#/definitions/uuid"
+    }
+  },
+  "additionalProperties": false
+}

--- a/generate_schema/agency/start_trip.json
+++ b/generate_schema/agency/start_trip.json
@@ -49,7 +49,7 @@
     "location": {
       "$id": "#/properties/location",
       "description": "The GPS coordinates of where the event occurred",
-      "$ref": "#/definitions/Point"
+      "$ref": "#/definitions/MDS_Feature_Point"
     },
     "timestamp": {
       "$id": "#/properties/location",

--- a/generate_schema/agency/start_trip.json
+++ b/generate_schema/agency/start_trip.json
@@ -1,0 +1,60 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/start_trip.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, start_trip payload",
+  "type": "object",
+  "definitions": {},
+  "required": [
+    "unique_id",
+    "provider_id",
+    "vehicle_id",
+    "timestamp",
+    "location",
+    "accuracy"
+  ],
+  "properties": {
+    "unique_id": {
+      "$id": "#/properties/unique_id",
+      "description": "The UUID for the vehicle, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "provider_id": {
+      "$id": "#/properties/provider_id",
+      "description": "The UUID for the Provider, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "vehicle_id": {
+      "$id": "#/properties/vehicle_id",
+      "type": "string",
+      "description": "The Vehicle Identification Number visible on the vehicle itself",
+      "default": "",
+      "examples": [
+        "ABC123"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "battery_pct_start": {
+      "$id": "#/properties/battery_pct_start",
+      "$ref": "#/definitions/battery_pct"
+    },
+    "accuracy": {
+      "$id": "#/properties/accuracy",
+      "type": "integer",
+      "title": "The approximate level of accuracy, in meters, of Points within route",
+      "default": 0,
+      "examples": [
+        15
+      ]
+    },
+    "location": {
+      "$id": "#/properties/location",
+      "description": "The GPS coordinates of where the event occurred",
+      "$ref": "#/definitions/Point"
+    },
+    "timestamp": {
+      "$id": "#/properties/location",
+      "$ref": "#/definitions/timestamp"
+    }
+  },
+  "additionalProperties": false
+}

--- a/generate_schema/agency/update_trip_telemetry.json
+++ b/generate_schema/agency/update_trip_telemetry.json
@@ -1,0 +1,38 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/update_trip_telemetry.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, update_trip_telemetry payload",
+  "type": "object",
+  "definitions": {},
+  "required": [
+    "trip_id",
+    "timestamp",
+    "route",
+    "accuracy"
+  ],
+  "properties": {
+    "trip_id": {
+      "$id": "#/properties/trip_id",
+      "description": "The UUID for the trip.",
+      "$ref": "#/definitions/uuid"
+    },
+    "accuracy": {
+      "$id": "#/properties/accuracy",
+      "type": "integer",
+      "title": "The approximate level of accuracy, in meters, of Points within route",
+      "default": 0,
+      "examples": [
+        15
+      ]
+    },
+    "route": {
+      "$id": "#/properties/location",
+      "$ref": "#/definitions/MDS_FeatureCollection_Route"
+    },
+    "timestamp": {
+      "$id": "#/properties/location",
+      "$ref": "#/definitions/timestamp"
+    }
+  },
+  "additionalProperties": false
+}

--- a/generate_schema/agency/update_vehicle_status.json
+++ b/generate_schema/agency/update_vehicle_status.json
@@ -1,0 +1,41 @@
+{
+  "$id": "https://raw.githubusercontent.com/CityofLosAngeles/mobility-data-specification/master/agency/update_vehicle_status.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Agency Schema, update_vehicle_status payload",
+  "type": "object",
+  "definitions": {},
+  "required": [
+    "unique_id",
+    "timestamp",
+    "location",
+    "event_type",
+    "event_type_reason"
+  ],
+  "oneOf": [
+    { "$ref": "#definitions/available_event" },
+    { "$ref": "#definitions/unavailable_event" },
+    { "$ref": "#definitions/reserved_event" },
+    { "$ref": "#definitions/removed_event" }
+  ],
+  "properties": {
+    "unique_id": {
+      "$id": "#/properties/unique_id",
+      "description": "The UUID for the vehicle, unique within MDS",
+      "$ref": "#/definitions/uuid"
+    },
+    "battery_pct": {
+      "$id": "#/properties/battery_pct",
+      "$ref": "#/definitions/battery_pct"
+    },
+    "location": {
+      "$id": "#/properties/location",
+      "description": "The GPS coordinates of where the event occurred",
+      "$ref": "#/definitions/Point"
+    },
+    "timestamp": {
+      "$id": "#/properties/location",
+      "$ref": "#/definitions/timestamp"
+    }
+  },
+  "additionalProperties": false
+}

--- a/generate_schema/agency/update_vehicle_status.json
+++ b/generate_schema/agency/update_vehicle_status.json
@@ -30,7 +30,7 @@
     "location": {
       "$id": "#/properties/location",
       "description": "The GPS coordinates of where the event occurred",
-      "$ref": "#/definitions/Point"
+      "$ref": "#/definitions/MDS_Feature_Point"
     },
     "timestamp": {
       "$id": "#/properties/location",

--- a/generate_schema/agency/update_vehicle_status.json
+++ b/generate_schema/agency/update_vehicle_status.json
@@ -12,10 +12,10 @@
     "event_type_reason"
   ],
   "oneOf": [
-    { "$ref": "#definitions/available_event" },
-    { "$ref": "#definitions/unavailable_event" },
-    { "$ref": "#definitions/reserved_event" },
-    { "$ref": "#definitions/removed_event" }
+    { "$ref": "#/definitions/available_event" },
+    { "$ref": "#/definitions/unavailable_event" },
+    { "$ref": "#/definitions/reserved_event" },
+    { "$ref": "#/definitions/removed_event" }
   ],
   "properties": {
     "unique_id": {

--- a/generate_schema/common.json
+++ b/generate_schema/common.json
@@ -38,6 +38,17 @@
       },
       "minItems": 1
     },
+    "battery_pct": {
+      "$id": "#/definitions/battery_pct",
+      "type": "number",
+      "description": "Percent charge of device battery, expressed between 0 and 1",
+      "default": 0.0,
+      "examples": [
+        0.89
+      ],
+      "minimum": 0,
+      "maximum": 1
+    },
     "vehicle_type": {
       "$id": "#/definitions/vehicle_type",
       "type": "string",

--- a/generate_schema/common.json
+++ b/generate_schema/common.json
@@ -47,6 +47,97 @@
         "scooter"
       ]
     },
+    "available_event": {
+      "$id": "#/definitions/available_event",
+      "type": "object",
+      "description": "An event type describing a vehicle becoming available",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "The type of the event",
+          "enum": [
+            "available"
+          ]
+        },
+        "event_type_reason": {
+          "type": "string",
+          "description": "The reason for the event",
+          "enum": [
+            "service_start",
+            "user_drop_off",
+            "rebalance_drop_off",
+            "maintenance_drop_off"
+          ]
+        }
+      }
+    },
+    "reserved_event": {
+      "$id": "#/definitions/reserved_event",
+      "type": "object",
+      "description": "An event type describing a vehicle becoming reserved",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "The type of the event",
+          "enum": [
+            "reserved"
+          ]
+        },
+        "event_type_reason": {
+          "type": "string",
+          "description": "The reason for the event",
+          "enum": [
+            "user_pick_up"
+          ]
+        }
+      }
+    },
+    "unavailable_event": {
+      "$id": "#/definitions/unavailable_event",
+      "type": "object",
+      "description": "An event type describing a vehicle becoming unavailable",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "The type of the event",
+          "enum": [
+            "unavailable"
+          ]
+        },
+        "event_type_reason": {
+          "type": "string",
+          "description": "The reason for the event",
+          "enum": [
+            "default",
+            "low_battery",
+            "maintenance"
+          ]
+        }
+      }
+    },
+    "removed_event": {
+      "$id": "#/definitions/removed_event",
+      "type": "object",
+      "description": "An event type describing a vehicle becoming removed",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "The type of the event",
+          "enum": [
+            "removed"
+          ]
+        },
+        "event_type_reason": {
+          "type": "string",
+          "description": "The reason for the event",
+          "enum": [
+            "service_end",
+            "rebalance_pick_up",
+            "maintenance_pick_up"
+          ]
+        }
+      }
+    },
     "links": {
       "$id": "#/definitions/links",
       "type": "object",

--- a/generate_schema/generate_provider_schema.py
+++ b/generate_schema/generate_provider_schema.py
@@ -148,6 +148,10 @@ if __name__ == '__main__':
             "vehicle_type": common["definitions"]["vehicle_type"],
             "version": common["definitions"]["version"],
             "uuid": common["definitions"]["uuid"],
+            "available_event": common["definitions"]["available_event"],
+            "unavailable_event": common["definitions"]["unavailable_event"],
+            "reserved_event": common["definitions"]["reserved_event"],
+            "removed_event": common["definitions"]["removed_event"],
             }
 
     # Check that it is a valid schema

--- a/generate_schema/generate_schema.py
+++ b/generate_schema/generate_schema.py
@@ -148,6 +148,7 @@ if __name__ == '__main__':
             "vehicle_type": common["definitions"]["vehicle_type"],
             "version": common["definitions"]["version"],
             "uuid": common["definitions"]["uuid"],
+            "battery_pct": common["definitions"]["battery_pct"],
             "available_event": common["definitions"]["available_event"],
             "unavailable_event": common["definitions"]["unavailable_event"],
             "reserved_event": common["definitions"]["reserved_event"],
@@ -159,3 +160,30 @@ if __name__ == '__main__':
     # Write to the `provider` directory.
     with open("../provider/status_changes.json", "w") as statusfile:
         statusfile.write(json.dumps(status_changes, indent=2))
+
+    # Create the standalone register_vehicle JSON schema by including the needed definitions
+    register_vehicle = get_json_file('agency/register_vehicle.json')
+    register_vehicle["definitions"] = {
+            "propulsion_type": common["definitions"]["propulsion_type"],
+            "vehicle_type": common["definitions"]["vehicle_type"],
+            "uuid": common["definitions"]["uuid"],
+            }
+
+    # Check that it is a valid schema
+    jsonschema.Draft6Validator.check_schema(register_vehicle)
+    # Write to the `provider` directory.
+    with open("../agency/register_vehicle.json", "w") as rvfile:
+        rvfile.write(json.dumps(register_vehicle, indent=2))
+
+    # Create the standalone deregister_vehicle JSON schema by including the needed definitions
+    deregister_vehicle = get_json_file('agency/deregister_vehicle.json')
+    deregister_vehicle["definitions"] = {
+            "uuid": common["definitions"]["uuid"],
+            "battery_pct": common["definitions"]["battery_pct"],
+            }
+
+    # Check that it is a valid schema
+    jsonschema.Draft6Validator.check_schema(deregister_vehicle)
+    # Write to the `provider` directory.
+    with open("../agency/deregister_vehicle.json", "w") as rvfile:
+        rvfile.write(json.dumps(deregister_vehicle, indent=2))

--- a/generate_schema/generate_schema.py
+++ b/generate_schema/generate_schema.py
@@ -192,6 +192,7 @@ if __name__ == '__main__':
     update_vehicle_status = get_json_file('agency/update_vehicle_status.json')
     update_vehicle_status["definitions"] = {
             POINT: point,
+            MDS_FEATURE_POINT: mds_feature_point,
             "uuid": common["definitions"]["uuid"],
             "battery_pct": common["definitions"]["battery_pct"],
             "timestamp": common["definitions"]["timestamp"],
@@ -212,6 +213,7 @@ if __name__ == '__main__':
     start_trip = get_json_file('agency/start_trip.json')
     start_trip["definitions"] = {
             POINT: point,
+            MDS_FEATURE_POINT: mds_feature_point,
             "uuid": common["definitions"]["uuid"],
             "battery_pct": common["definitions"]["battery_pct"],
             "timestamp": common["definitions"]["timestamp"],
@@ -228,6 +230,7 @@ if __name__ == '__main__':
     end_trip = get_json_file('agency/end_trip.json')
     end_trip["definitions"] = {
             POINT: point,
+            MDS_FEATURE_POINT: mds_feature_point,
             "uuid": common["definitions"]["uuid"],
             "battery_pct": common["definitions"]["battery_pct"],
             "timestamp": common["definitions"]["timestamp"],
@@ -243,6 +246,8 @@ if __name__ == '__main__':
     # Create the standalone update_trip_telemetry JSON schema by including the needed definitions
     update_trip_telemetry = get_json_file('agency/update_trip_telemetry.json')
     update_trip_telemetry["definitions"] = {
+            POINT: point,
+            MDS_FEATURE_POINT: mds_feature_point,
             MDS_FEATURECOLLECTION_ROUTE: mds_feature_collection_route,
             "uuid": common["definitions"]["uuid"],
             "timestamp": common["definitions"]["timestamp"],

--- a/generate_schema/generate_schema.py
+++ b/generate_schema/generate_schema.py
@@ -185,5 +185,84 @@ if __name__ == '__main__':
     # Check that it is a valid schema
     jsonschema.Draft6Validator.check_schema(deregister_vehicle)
     # Write to the `provider` directory.
-    with open("../agency/deregister_vehicle.json", "w") as rvfile:
-        rvfile.write(json.dumps(deregister_vehicle, indent=2))
+    with open("../agency/deregister_vehicle.json", "w") as drvfile:
+        drvfile.write(json.dumps(deregister_vehicle, indent=2))
+
+    # Create the standalone update_vehicle_status JSON schema by including the needed definitions
+    update_vehicle_status = get_json_file('agency/update_vehicle_status.json')
+    update_vehicle_status["definitions"] = {
+            POINT: point,
+            "uuid": common["definitions"]["uuid"],
+            "battery_pct": common["definitions"]["battery_pct"],
+            "timestamp": common["definitions"]["timestamp"],
+            "available_event": common["definitions"]["available_event"],
+            "unavailable_event": common["definitions"]["unavailable_event"],
+            "reserved_event": common["definitions"]["reserved_event"],
+            "removed_event": common["definitions"]["removed_event"],
+            }
+
+    # Check that it is a valid schema
+    jsonschema.Draft6Validator.check_schema(update_vehicle_status)
+    # Write to the `provider` directory.
+    with open("../agency/update_vehicle_status.json", "w") as uvsfile:
+        uvsfile.write(json.dumps(update_vehicle_status, indent=2))
+
+
+    # Create the standalone start_trip JSON schema by including the needed definitions
+    start_trip = get_json_file('agency/start_trip.json')
+    start_trip["definitions"] = {
+            POINT: point,
+            "uuid": common["definitions"]["uuid"],
+            "battery_pct": common["definitions"]["battery_pct"],
+            "timestamp": common["definitions"]["timestamp"],
+            }
+
+    # Check that it is a valid schema
+    jsonschema.Draft6Validator.check_schema(start_trip)
+    # Write to the `provider` directory.
+    with open("../agency/start_trip.json", "w") as stfile:
+        stfile.write(json.dumps(start_trip, indent=2))
+
+
+    # Create the standalone end_trip JSON schema by including the needed definitions
+    end_trip = get_json_file('agency/end_trip.json')
+    end_trip["definitions"] = {
+            POINT: point,
+            "uuid": common["definitions"]["uuid"],
+            "battery_pct": common["definitions"]["battery_pct"],
+            "timestamp": common["definitions"]["timestamp"],
+            }
+
+    # Check that it is a valid schema
+    jsonschema.Draft6Validator.check_schema(end_trip)
+    # Write to the `provider` directory.
+    with open("../agency/end_trip.json", "w") as etfile:
+        etfile.write(json.dumps(end_trip, indent=2))
+
+
+    # Create the standalone update_trip_telemetry JSON schema by including the needed definitions
+    update_trip_telemetry = get_json_file('agency/update_trip_telemetry.json')
+    update_trip_telemetry["definitions"] = {
+            MDS_FEATURECOLLECTION_ROUTE: mds_feature_collection_route,
+            "uuid": common["definitions"]["uuid"],
+            "timestamp": common["definitions"]["timestamp"],
+            }
+
+    # Check that it is a valid schema
+    jsonschema.Draft6Validator.check_schema(update_trip_telemetry)
+    # Write to the `provider` directory.
+    with open("../agency/update_trip_telemetry.json", "w") as uttfile:
+        uttfile.write(json.dumps(update_trip_telemetry, indent=2))
+
+
+    # Create the standalone service_areas JSON schema by including the needed definitions
+    service_areas = get_json_file('agency/service_areas.json')
+    service_areas["definitions"] = {
+            "uuid": common["definitions"]["uuid"],
+            }
+
+    # Check that it is a valid schema
+    jsonschema.Draft6Validator.check_schema(service_areas)
+    # Write to the `provider` directory.
+    with open("../agency/service_areas.json", "w") as safile:
+        safile.write(json.dumps(service_areas, indent=2))

--- a/generate_schema/provider/status_changes.json
+++ b/generate_schema/provider/status_changes.json
@@ -42,85 +42,10 @@
               "event_location"
             ],
             "oneOf": [
-              {
-                "properties": {
-                  "event_type": {
-                    "type": "string",
-                    "description": "The type of the event",
-                    "enum": [
-                      "available"
-                    ]
-                  },
-                  "event_type_reason": {
-                    "type": "string",
-                    "description": "The reason for the event",
-                    "enum": [
-                      "service_start",
-                      "user_drop_off",
-                      "rebalance_drop_off",
-                      "maintenance_drop_off"
-                    ]
-                  }
-                }
-              },
-              {
-                "properties": {
-                  "event_type": {
-                    "type": "string",
-                    "description": "The type of the event",
-                    "enum": [
-                      "reserved"
-                    ]
-                  },
-                  "event_type_reason": {
-                    "type": "string",
-                    "description": "The reason for the event",
-                    "enum": [
-                      "user_pick_up"
-                    ]
-                  }
-                }
-              },
-              {
-                "properties": {
-                  "event_type": {
-                    "type": "string",
-                    "description": "The type of the event",
-                    "enum": [
-                      "unavailable"
-                    ]
-                  },
-                  "event_type_reason": {
-                    "type": "string",
-                    "description": "The reason for the event",
-                    "enum": [
-                      "default",
-                      "low_battery",
-                      "maintenance"
-                    ]
-                  }
-                }
-              },
-              {
-                "properties": {
-                  "event_type": {
-                    "type": "string",
-                    "description": "The type of the event",
-                    "enum": [
-                      "removed"
-                    ]
-                  },
-                  "event_type_reason": {
-                    "type": "string",
-                    "description": "The reason for the event",
-                    "enum": [
-                      "service_end",
-                      "rebalance_pick_up",
-                      "maintenance_pick_up"
-                    ]
-                  }
-                }
-              }
+              { "$ref": "#definitions/available_event" },
+              { "$ref": "#definitions/unavailable_event" },
+              { "$ref": "#definitions/reserved_event" },
+              { "$ref": "#definitions/removed_event" }
             ],
             "properties": {
               "provider_name": {

--- a/generate_schema/provider/status_changes.json
+++ b/generate_schema/provider/status_changes.json
@@ -42,10 +42,10 @@
               "event_location"
             ],
             "oneOf": [
-              { "$ref": "#definitions/available_event" },
-              { "$ref": "#definitions/unavailable_event" },
-              { "$ref": "#definitions/reserved_event" },
-              { "$ref": "#definitions/removed_event" }
+              { "$ref": "#/definitions/available_event" },
+              { "$ref": "#/definitions/unavailable_event" },
+              { "$ref": "#/definitions/reserved_event" },
+              { "$ref": "#/definitions/removed_event" }
             ],
             "properties": {
               "provider_name": {

--- a/generate_schema/provider/status_changes.json
+++ b/generate_schema/provider/status_changes.json
@@ -103,14 +103,7 @@
               },
               "battery_pct": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/battery_pct",
-                "type": "number",
-                "description": "Percent charge of device battery, expressed between 0 and 1",
-                "default": 0.0,
-                "examples": [
-                  0.89
-                ],
-                "minimum": 0,
-                "maximum": 1
+                "$ref": "#/definitions/battery_pct"
               },
               "associated_trips": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/associated_trips",

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -178,6 +178,17 @@
       ],
       "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
     },
+    "battery_pct": {
+      "$id": "#/definitions/battery_pct",
+      "type": "number",
+      "description": "Percent charge of device battery, expressed between 0 and 1",
+      "default": 0.0,
+      "examples": [
+        0.89
+      ],
+      "minimum": 0,
+      "maximum": 1
+    },
     "available_event": {
       "$id": "#/definitions/available_event",
       "type": "object",
@@ -221,6 +232,27 @@
             "default",
             "low_battery",
             "maintenance"
+          ]
+        }
+      }
+    },
+    "reserved_event": {
+      "$id": "#/definitions/reserved_event",
+      "type": "object",
+      "description": "An event type describing a vehicle becoming reserved",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "The type of the event",
+          "enum": [
+            "reserved"
+          ]
+        },
+        "event_type_reason": {
+          "type": "string",
+          "description": "The reason for the event",
+          "enum": [
+            "user_pick_up"
           ]
         }
       }
@@ -356,14 +388,7 @@
               },
               "battery_pct": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/battery_pct",
-                "type": "number",
-                "description": "Percent charge of device battery, expressed between 0 and 1",
-                "default": 0.0,
-                "examples": [
-                  0.89
-                ],
-                "minimum": 0,
-                "maximum": 1
+                "$ref": "#/definitions/battery_pct"
               },
               "associated_trips": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/associated_trips",

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -320,16 +320,16 @@
             ],
             "oneOf": [
               {
-                "$ref": "#definitions/available_event"
+                "$ref": "#/definitions/available_event"
               },
               {
-                "$ref": "#definitions/unavailable_event"
+                "$ref": "#/definitions/unavailable_event"
               },
               {
-                "$ref": "#definitions/reserved_event"
+                "$ref": "#/definitions/reserved_event"
               },
               {
-                "$ref": "#definitions/removed_event"
+                "$ref": "#/definitions/removed_event"
               }
             ],
             "properties": {

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -47,12 +47,19 @@
       "properties": {
         "type": {
           "type": "string",
-          "emum": [
+          "enum": [
             "Feature"
           ]
         },
         "properties": {
-          "type": "object",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object"
+            }
+          ],
           "required": [
             "timestamp"
           ],
@@ -170,6 +177,76 @@
         "3c9604d6-b5ee-11e8-96f8-529269fb1459"
       ],
       "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+    },
+    "available_event": {
+      "$id": "#/definitions/available_event",
+      "type": "object",
+      "description": "An event type describing a vehicle becoming available",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "The type of the event",
+          "enum": [
+            "available"
+          ]
+        },
+        "event_type_reason": {
+          "type": "string",
+          "description": "The reason for the event",
+          "enum": [
+            "service_start",
+            "user_drop_off",
+            "rebalance_drop_off",
+            "maintenance_drop_off"
+          ]
+        }
+      }
+    },
+    "unavailable_event": {
+      "$id": "#/definitions/unavailable_event",
+      "type": "object",
+      "description": "An event type describing a vehicle becoming unavailable",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "The type of the event",
+          "enum": [
+            "unavailable"
+          ]
+        },
+        "event_type_reason": {
+          "type": "string",
+          "description": "The reason for the event",
+          "enum": [
+            "default",
+            "low_battery",
+            "maintenance"
+          ]
+        }
+      }
+    },
+    "removed_event": {
+      "$id": "#/definitions/removed_event",
+      "type": "object",
+      "description": "An event type describing a vehicle becoming removed",
+      "properties": {
+        "event_type": {
+          "type": "string",
+          "description": "The type of the event",
+          "enum": [
+            "removed"
+          ]
+        },
+        "event_type_reason": {
+          "type": "string",
+          "description": "The reason for the event",
+          "enum": [
+            "service_end",
+            "rebalance_pick_up",
+            "maintenance_pick_up"
+          ]
+        }
+      }
     }
   },
   "required": [
@@ -211,83 +288,16 @@
             ],
             "oneOf": [
               {
-                "properties": {
-                  "event_type": {
-                    "type": "string",
-                    "description": "The type of the event",
-                    "enum": [
-                      "available"
-                    ]
-                  },
-                  "event_type_reason": {
-                    "type": "string",
-                    "description": "The reason for the event",
-                    "enum": [
-                      "service_start",
-                      "user_drop_off",
-                      "rebalance_drop_off",
-                      "maintenance_drop_off"
-                    ]
-                  }
-                }
+                "$ref": "#definitions/available_event"
               },
               {
-                "properties": {
-                  "event_type": {
-                    "type": "string",
-                    "description": "The type of the event",
-                    "enum": [
-                      "reserved"
-                    ]
-                  },
-                  "event_type_reason": {
-                    "type": "string",
-                    "description": "The reason for the event",
-                    "enum": [
-                      "user_pick_up"
-                    ]
-                  }
-                }
+                "$ref": "#definitions/unavailable_event"
               },
               {
-                "properties": {
-                  "event_type": {
-                    "type": "string",
-                    "description": "The type of the event",
-                    "enum": [
-                      "unavailable"
-                    ]
-                  },
-                  "event_type_reason": {
-                    "type": "string",
-                    "description": "The reason for the event",
-                    "enum": [
-                      "default",
-                      "low_battery",
-                      "maintenance"
-                    ]
-                  }
-                }
+                "$ref": "#definitions/reserved_event"
               },
               {
-                "properties": {
-                  "event_type": {
-                    "type": "string",
-                    "description": "The type of the event",
-                    "enum": [
-                      "removed"
-                    ]
-                  },
-                  "event_type_reason": {
-                    "type": "string",
-                    "description": "The reason for the event",
-                    "enum": [
-                      "service_end",
-                      "rebalance_pick_up",
-                      "maintenance_pick_up"
-                    ]
-                  }
-                }
+                "$ref": "#definitions/removed_event"
               }
             ],
             "properties": {

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -47,12 +47,19 @@
       "properties": {
         "type": {
           "type": "string",
-          "emum": [
+          "enum": [
             "Feature"
           ]
         },
         "properties": {
-          "type": "object",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object"
+            }
+          ],
           "required": [
             "timestamp"
           ],
@@ -85,7 +92,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "emum": [
+          "enum": [
             "FeatureCollection"
           ]
         },


### PR DESCRIPTION
Fixes #169. Partial fix for #168.

I have tried to hew as closely as I could to the description in the README, with a couple of exceptions for things I thought were mistakes or unclear:
* Should `reason_code` in the update vehicle status API instead be the same as `event_type_reason` from the `status_change` API? It seemed to me that it should from the narrative description.
* I have gone ahead and changed several of the points to be `MDS_Feature_Point`s as suggested in #168.
* `vehicle_type` and `propulsion_type` seemed out of sync with the provider API. I updated them.

These schema are as yet not very well tested, and I am not aware of any synthetic data to put them through the works. Do you have anything you could point me towards @hunterowens or @thekaveman?
Finally, I notice that the spec does not include `version` fields in them, as is the case for `provider`. Should we consider adding that?

I have not added schema for any of the agency response types at the moment.