### PR TITLE
Require Standard HTTP Status Codes for Provider

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -15,6 +15,8 @@ The following information applies to all `provider` API endpoints. Details on pr
 
 ### Response Format
 
+The response to a client request must include a status code defined in the [IANA HTTP Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
+
 Responses must be `UTF-8` encoded `application/json` and must minimally include the MDS `version` and a `data` payload:
 
 ```json


### PR DESCRIPTION
I initially proposed #113, which was correctly pointed out as a dupe of #105. However, looking at the relevant PR #156 , it only addresses the agency spec without also addressing Provider. This adds (some) clarification around standard HTTP status codes for the provider part of #105.  

I think that we could also have some language encouraging providers to be as specific as possible in the error response code and to avoid 500 when possible, though maybe this is too much. Open to suggestions.

I added it under Response Format, but open to other ideas if there is a better placement elsewhere.