### PR TITLE
Revert 146

### DIFF
--- a/generate_schema/Pipfile
+++ b/generate_schema/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 
 [dev-packages]
-jsonschema = "==3.0.0a2"
+jsonschema = ">=3.0.0a2"
 requests = "*"
 
 [requires]

--- a/generate_schema/Pipfile.lock
+++ b/generate_schema/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1f42bd8cbd742609dd9ee86bd613c4dee94c70ca173730fd08162347b021e1ae"
+            "sha256": "a80040a2420388618496541cdd1f3ff7dc9bda61b92f7472dbf236dfd2777452"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -15,8 +15,7 @@
             }
         ]
     },
-    "default": {},
-    "develop": {
+    "default": {
         "attrs": {
             "hashes": [
                 "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
@@ -61,11 +60,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c",
-                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279"
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
             "index": "pypi",
-            "version": "==2.20.0"
+            "version": "==2.19.1"
         },
         "six": {
             "hashes": [
@@ -76,10 +75,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
-                "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "version": "==1.24"
+            "version": "==1.23"
         }
-    }
+    },
+    "develop": {}
 }

--- a/generate_schema/common.json
+++ b/generate_schema/common.json
@@ -108,10 +108,9 @@
     },
     "timestamp": {
       "$id": "#/definitions/timestamp",
-      "title": "Integer seconds since Unix epoch",
+      "title": "Floating-point seconds since Unix epoch",
       "type": "number",
-      "multiple_of": 1.0, 
-      "minimum": 1483228800 
+      "minimum": 0.0
     }
   }
 }

--- a/generate_schema/common.json
+++ b/generate_schema/common.json
@@ -108,10 +108,10 @@
     },
     "timestamp": {
       "$id": "#/definitions/timestamp",
-      "title": "Integer milliseconds since Unix epoch",
+      "title": "Integer seconds since Unix epoch",
       "type": "number",
-      "multipleOf": 1.0, 
-      "minimum": 0 
+      "multiple_of": 1.0, 
+      "minimum": 1483228800 
     }
   }
 }

--- a/generate_schema/generate_provider_schema.py
+++ b/generate_schema/generate_provider_schema.py
@@ -53,7 +53,6 @@ def get_feature_schema(id=None, title=None, geometry=None, properties=None, requ
 
     f_properties = feature["properties"]["properties"]
     if required is not None:
-        del f_properties["oneOf"]
         f_properties["required"] = required
     if properties is not None:
         f_properties["properties"] = properties

--- a/generate_schema/generate_provider_schema.py
+++ b/generate_schema/generate_provider_schema.py
@@ -13,7 +13,7 @@ MDS_FEATURE_POINT = "MDS_Feature_Point"
 MDS_FEATURECOLLECTION_ROUTE = "MDS_FeatureCollection_Route"
 
 def get_definition(id):
-    return f"#/definitions/{id}"
+    return "#/definitions/{}".format(id)
 
 def get_point_schema():
     """

--- a/generate_schema/provider/status_changes.json
+++ b/generate_schema/provider/status_changes.json
@@ -163,8 +163,12 @@
               },
               "event_time": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/event_time",
+                "type": "number",
                 "description": "The time the event occurred, expressed as a Unix Timestamp",
-                "$ref": "#/definitions/timestamp"
+                "default": 0.0,
+                "examples": [
+                  1529968782.421409
+                ]
               },
               "event_location": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/event_location",

--- a/generate_schema/provider/trips.json
+++ b/generate_schema/provider/trips.json
@@ -123,13 +123,21 @@
               },
               "start_time": {
                 "$id": "#/properties/data/properties/trips/items/properties/start_time",
+                "type": "number",
                 "description": "The time the trip began, expressed as a Unix Timestamp",
-                "$ref": "#/definitions/timestamp"
+                "default": 0.0,
+                "examples": [
+                  1529968782.421409
+                ]
               },
               "end_time": {
                 "$id": "#/properties/data/properties/trips/items/properties/end_time",
+                "type": "number",
                 "description": "The time the trip ended, expressed as a Unix Timestamp",
-                "$ref": "#/definitions/timestamp"
+                "default": 0.0,
+                "examples": [
+                  1531007628.3774529
+                ]
               },
               "parking_verification_url": {
                 "$id": "#/properties/data/properties/trips/items/properties/parking_verification_url",

--- a/provider/README.md
+++ b/provider/README.md
@@ -85,7 +85,7 @@ represented as a GeoJSON [`Feature`](https://tools.ietf.org/html/rfc7946#section
 {
     "type": "Feature",
     "properties": {
-        "timestamp": 1529968782421
+        "timestamp": 1529968782.421409
     },
     "geometry": {
         "type": "Point",
@@ -101,7 +101,8 @@ represented as a GeoJSON [`Feature`](https://tools.ietf.org/html/rfc7946#section
 
 ### Timestamps
 
-References to `timestamp` imply integer milliseconds since [Unix epoch](https://en.wikipedia.org/wiki/Unix_time). You can find the implementation of unix timestamp in milliseconds for your programming language [here](https://currentmillis.com/).
+References to `timestamp` imply floating-point seconds since [Unix epoch](https://en.wikipedia.org/wiki/Unix_time), such as
+the format returned by Python's [`time.time()`](https://docs.python.org/3/library/time.html#time.time) function.
 
 [Top][toc]
 
@@ -186,7 +187,7 @@ Routes must include at least 2 points: the start point and end point. Additional
     "features": [{
         "type": "Feature",
         "properties": {
-            "timestamp": 1529968782421
+            "timestamp": 1529968782.421409
         },
         "geometry": {
             "type": "Point",
@@ -199,7 +200,7 @@ Routes must include at least 2 points: the start point and end point. Additional
     {
         "type": "Feature",
         "properties": {
-            "timestamp": 1531007628377
+            "timestamp": 1531007628.3774529
         },
         "geometry": {
             "type": "Point",

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -52,6 +52,14 @@
           ]
         },
         "properties": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object"
+            }
+          ],
           "required": [
             "timestamp"
           ],

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -350,8 +350,12 @@
               },
               "event_time": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/event_time",
+                "type": "number",
                 "description": "The time the event occurred, expressed as a Unix Timestamp",
-                "$ref": "#/definitions/timestamp"
+                "default": 0.0,
+                "examples": [
+                  1529968782.421409
+                ]
               },
               "event_location": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/event_location",
@@ -360,10 +364,7 @@
               },
               "battery_pct": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/battery_pct",
-                "type": [
-                  "number",
-                  "null"
-                ],
+                "type": ["number", "null"],
                 "description": "Percent charge of device battery, expressed between 0 and 1",
                 "examples": [
                   0.89
@@ -373,10 +374,7 @@
               },
               "associated_trips": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/associated_trips",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "description": "For 'Reserved' event types, associated trip_ids",
                 "items": {
                   "$id": "#/properties/data/properties/status_changes/items/properties/associated_trips/items",

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -47,7 +47,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "emum": [
+          "enum": [
             "Feature"
           ]
         },

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -157,10 +157,10 @@
     },
     "timestamp": {
       "$id": "#/definitions/timestamp",
-      "title": "Integer milliseconds since Unix epoch",
+      "title": "Integer seconds since Unix epoch",
       "type": "number",
-      "multipleOf": 1.0,
-      "minimum": 0
+      "multiple_of": 1.0,
+      "minimum": 1483228800
     },
     "vehicle_type": {
       "$id": "#/definitions/vehicle_type",

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -47,19 +47,12 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
+          "emum": [
             "Feature"
           ]
         },
         "properties": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "object"
-            }
-          ],
+          "type": "object",
           "required": [
             "timestamp"
           ],
@@ -157,10 +150,9 @@
     },
     "timestamp": {
       "$id": "#/definitions/timestamp",
-      "title": "Integer seconds since Unix epoch",
+      "title": "Floating-point seconds since Unix epoch",
       "type": "number",
-      "multiple_of": 1.0,
-      "minimum": 1483228800
+      "minimum": 0.0
     },
     "vehicle_type": {
       "$id": "#/definitions/vehicle_type",

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -188,10 +188,10 @@
     },
     "timestamp": {
       "$id": "#/definitions/timestamp",
-      "title": "Integer milliseconds since Unix epoch",
+      "title": "Integer seconds since Unix epoch",
       "type": "number",
-      "multipleOf": 1.0,
-      "minimum": 0
+      "multiple_of": 1.0,
+      "minimum": 1483228800
     },
     "vehicle_type": {
       "$id": "#/definitions/vehicle_type",

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -47,7 +47,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "emum": [
+          "enum": [
             "Feature"
           ]
         },
@@ -85,7 +85,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "emum": [
+          "enum": [
             "FeatureCollection"
           ]
         },

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -52,6 +52,14 @@
           ]
         },
         "properties": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object"
+            }
+          ],
           "required": [
             "timestamp"
           ],

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -341,20 +341,25 @@
               },
               "start_time": {
                 "$id": "#/properties/data/properties/trips/items/properties/start_time",
+                "type": "number",
                 "description": "The time the trip began, expressed as a Unix Timestamp",
-                "$ref": "#/definitions/timestamp"
+                "default": 0.0,
+                "examples": [
+                  1529968782.421409
+                ]
               },
               "end_time": {
                 "$id": "#/properties/data/properties/trips/items/properties/end_time",
+                "type": "number",
                 "description": "The time the trip ended, expressed as a Unix Timestamp",
-                "$ref": "#/definitions/timestamp"
+                "default": 0.0,
+                "examples": [
+                  1531007628.3774529
+                ]
               },
               "parking_verification_url": {
                 "$id": "#/properties/data/properties/trips/items/properties/parking_verification_url",
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": ["string", "null"],
                 "description": "A URL to a photo (or other evidence) of proper vehicle parking",
                 "examples": [
                   "https://data.provider.co/parking_verify/1234.jpg"
@@ -363,10 +368,7 @@
               },
               "standard_cost": {
                 "$id": "#/properties/data/properties/trips/items/properties/standard_cost",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "description": "The cost, in cents, that it would cost to perform the trip in the standard operation of the System",
                 "examples": [
                   500
@@ -374,10 +376,7 @@
               },
               "actual_cost": {
                 "$id": "#/properties/data/properties/trips/items/properties/actual_cost",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "description": "The actual cost, in cents, paid by the customer of the mobility as a service provider",
                 "examples": [
                   520

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -47,19 +47,12 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
+          "emum": [
             "Feature"
           ]
         },
         "properties": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "object"
-            }
-          ],
+          "type": "object",
           "required": [
             "timestamp"
           ],
@@ -92,7 +85,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
+          "emum": [
             "FeatureCollection"
           ]
         },
@@ -188,10 +181,9 @@
     },
     "timestamp": {
       "$id": "#/definitions/timestamp",
-      "title": "Integer seconds since Unix epoch",
+      "title": "Floating-point seconds since Unix epoch",
       "type": "number",
-      "multiple_of": 1.0,
-      "minimum": 1483228800
+      "minimum": 0.0
     },
     "vehicle_type": {
       "$id": "#/definitions/vehicle_type",


### PR DESCRIPTION
This PR reverts all changes made in PR #146, so that we don't merge the milliseconds since epoch unix timestamp feature. This is paired with PR #179, which cherry-picked those changes. If we squash and merge this, we can cut version 0.2.1. 