### PR TITLE
Fix for required properties in generated schema

### DIFF
--- a/generate_schema/generate_provider_schema.py
+++ b/generate_schema/generate_provider_schema.py
@@ -53,6 +53,8 @@ def get_feature_schema(id=None, title=None, geometry=None, properties=None, requ
 
     f_properties = feature["properties"]["properties"]
     if required is not None:
+        del f_properties["oneOf"]
+        f_properties["type"] = "object"
         f_properties["required"] = required
     if properties is not None:
         f_properties["properties"] = properties

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -356,7 +356,10 @@
               },
               "battery_pct": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/battery_pct",
-                "type": ["number", "null"],
+                "type": [
+                  "number",
+                  "null"
+                ],
                 "description": "Percent charge of device battery, expressed between 0 and 1",
                 "examples": [
                   0.89
@@ -366,7 +369,10 @@
               },
               "associated_trips": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/associated_trips",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "description": "For 'Reserved' event types, associated trip_ids",
                 "items": {
                   "$id": "#/properties/data/properties/status_changes/items/properties/associated_trips/items",

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -351,7 +351,10 @@
               },
               "parking_verification_url": {
                 "$id": "#/properties/data/properties/trips/items/properties/parking_verification_url",
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "description": "A URL to a photo (or other evidence) of proper vehicle parking",
                 "examples": [
                   "https://data.provider.co/parking_verify/1234.jpg"
@@ -360,7 +363,10 @@
               },
               "standard_cost": {
                 "$id": "#/properties/data/properties/trips/items/properties/standard_cost",
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "description": "The cost, in cents, that it would cost to perform the trip in the standard operation of the System",
                 "examples": [
                   500
@@ -368,7 +374,10 @@
               },
               "actual_cost": {
                 "$id": "#/properties/data/properties/trips/items/properties/actual_cost",
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "description": "The actual cost, in cents, paid by the customer of the mobility as a service provider",
                 "examples": [
                   520


### PR DESCRIPTION
Remove the GeoJSON Feature `oneOf` allowance for properties when we are setting the required field. This makes the properties key itself required, and forces its type to object.

Ported from the #146/#179/#180 mess