### PR TITLE
Restructure api and add event-status model

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -1,6 +1,6 @@
 # Mobility Data Specification: **Agency**
 
-This specification contains a collection of RESTful APIs used to specify the digital relationship between *mobility as a service* Providers and the Agencies that regulate them.
+This specification contains a collection of RESTful APIs used to specify the digital relationship between *mobility as a service* providers and the agencies that regulate them.
 
 * Authors: LADOT
 * Date: 11 Dec 2018
@@ -25,28 +25,28 @@ When making requests, the Agency API expects `provider_id` to be part of the cla
 
 The `/vehicles` endpoint returns the specified vehicle.  Providers can only retrieve data for vehicles in their registered fleet.
 
-Endpoint: `/vehicles/{vehicle_id}`
+Endpoint: `/vehicles/{device_id}`
 Method: `GET`
 
 Path Params:
 
 | Param        | Type | Required/Optional | Description                                 |
 | ------------ | ---- | ----------------- | ------------------------------------------- |
-| `vehicle_id` | UUIDv4 | Optional          | If provided, retrieve the specified vehicle |
+| `device_id` | UUIDv4 | Optional          | If provided, retrieve the specified vehicle |
 
 200 Success Response:
 
 | Field         | Type           | Field Description                                                             |
 | ------------- | -------------- | ----------------------------------------------------------------------------- |
-| `vehicle_id`  | UUIDv4         | Provided by Operator to uniquely identify a vehicle                           |
+| `device_id`  | UUIDv4         | Provided by Operator to uniquely identify a vehicle                           |
 | `provider_id` | UUIDv4         | Issued by <insert here>                                                       |
-| `vin`         | String         | Vehicle Identification Number (VIN) visible on vehicle                        |
+| `vehicle_id`  | String         | Vehicle Identification Number (vehicle_id) visible on vehicle                        |
 | `type`        | Enum           | [Vehicle Type](#vehicle-type)                                                 |
 | `propulsion`  | Enum[]         | Array of [Propulsion Type](#propulsion-type); allows multiple values          |
 | `year`        | Integer        | Year Manufactured                                                             |
 | `mfgr`        | String         | Vehicle Manufacturer                                                          |
 | `model`       | String         | Vehicle Model                                                                 |
-| `status`      | Enum           | Vehicle status based on posted `event`. See [Vehicle Status](#vehicle-events) |
+| `status`      | Enum           | Current vehicle status. See [Vehicle Status](#vehicle-events)                 |
 | `prev_event`  | Enum           | Last [Vehicle Event](#vehicle-events)                                         |
 | `updated`     | Unix Timestamp | Date of last event update                                                     |
 
@@ -61,13 +61,13 @@ Body Params:
 
 | Field        | Type    | Required/Optional | Field Description                                                    |
 | ------------ | ------- | ----------------- | -------------------------------------------------------------------- |
-| `vehicle_id` | UUIDv4  | Required          | Provided by Operator to uniquely identify a vehicle                  |
-| `vin`        | String  | Required          | Vehicle Identification Number (VIN) visible on vehicle               |
+| `device_id` | UUIDv4  | Required          | Provided by Operator to uniquely identify a vehicle                  |
+| `vehicle_id` | String  | Required          | Vehicle Identification Number (vehicle_id) visible on vehicle               |
 | `type`       | Enum    | Required          | [Vehicle Type](#vehicle-type)                                        |
 | `propulsion` | Enum[]  | Required          | Array of [Propulsion Type](#propulsion-type); allows multiple values |
-| `year`       | Integer | Required          | Year Manufactured                                                    |
-| `mfgr`       | String  | Required          | Vehicle Manufacturer                                                 |
-| `model`      | String  | Required          | Vehicle Model                                                        |
+| `year`       | Integer | Optional          | Year Manufactured                                                    |
+| `mfgr`       | String  | Optional          | Vehicle Manufacturer                                                 |
+| `model`      | String  | Optional          | Vehicle Model                                                        |
 
 201 Success Response:
 
@@ -77,20 +77,20 @@ _No content returned on success._
 
 The vehicle `/event` endpoint allows the Provider to control the state of the vehicle including deregister a vehicle from the fleet.
 
-Endpoint: `/vehicles/{vehicle_id}/event`
+Endpoint: `/vehicles/{device_id}/event`
 Method: `POST`
 
 Path Params:
 
 | Field        | Type | Required/Optional | Field Description                        |
 | ------------ | ---- | ----------------- | ---------------------------------------- |
-| `vehicle_id` | UUIDv4 | Required          | ID used in [Register](#vehicle-register) |
+| `device_id` | UUIDv4 | Required          | ID used in [Register](#vehicle-register) |
 
 Body Params:
 
 | Field       | Type                         | Required/Optional | Field Description                                                                                                                          |
 | ----------- | ---------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `event`     | Enum                         | Required          | [Vehicle Event](#vehicle-events)                                                                                                           |
+| `event_type` | Enum                         | Required          | [Vehicle Event](#vehicle-events)                                                                                                           |
 | `telemetry` | [Telemetry](#telemetry-data) | Required          | Single point of telemetry                             |
 | `trip_id`   | UUIDv4                         | Optional          | UUID provided by Operator to uniquely identify the trip. Required for `trip_start`, `trip_end`, `trip_enter`, and `trip_leave` event types |
 
@@ -98,8 +98,8 @@ Body Params:
 
 | Field        | Type | Field Description                                                             |
 | ------------ | ---- | ----------------------------------------------------------------------------- |
-| `vehicle_id` | UUIDv4| UUID provided by Operator to uniquely identify a vehicle                      |
-| `status`     | Enum | Vehicle status based on posted `event`. See [Vehicle Status](#vehicle-events) |
+| `device_id` | UUIDv4| UUID provided by Operator to uniquely identify a vehicle                      |
+| `status`     | Enum | Vehicle status based on posted `event_type`. See [Vehicle Status](#vehicle-events) |
 
 
 ## update_trip_telemetry
@@ -193,7 +193,7 @@ Response:
 
 List of valid vehicle events and the resulting vehicle status if the event is sucessful.
 
-| `event`                | description                                                                                          | valid initial `status`                             | `status` on success | status_description                                                      |
+| `event_type`                | description                                                                                          | valid initial `status`                             | `status` on success | status_description                                                      |
 | ---------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------- | ----------------------------------------------------------------------- |
 | `service_start`        | Vehicle introduced into service at the beginning of the day (if program does not operate 24/7)       | `unavailable`, `removed`, `elsewhere`              | `available`         | Vehicle is on the street and available for customer use.                |
 | `trip_end`             | Customer ends trip and reservation                                                                   | `trip`                                             | `available`         |                                                                         |

--- a/agency/README.md
+++ b/agency/README.md
@@ -38,9 +38,9 @@ Path Params:
 
 | Field         | Type           | Field Description                                                             |
 | ------------- | -------------- | ----------------------------------------------------------------------------- |
-| `device_id`  | UUIDv4         | Provided by Operator to uniquely identify a vehicle                           |
-| `provider_id` | UUIDv4         | Issued by <insert here>                                                       |
-| `vehicle_id`  | String         | Vehicle Identification Number (vehicle_id) visible on vehicle                        |
+| `device_id`  | UUIDv4         | Provided by Operator to uniquely identify a vehicle                            |
+| `provider_id` | UUIDv4         | Issued by City and [tracked](../providers.csv)                                |
+| `vehicle_id`  | String         | Vehicle Identification Number (vehicle_id) visible on vehicle                 |
 | `type`        | Enum           | [Vehicle Type](#vehicle-type)                                                 |
 | `propulsion`  | Enum[]         | Array of [Propulsion Type](#propulsion-type); allows multiple values          |
 | `year`        | Integer        | Year Manufactured                                                             |


### PR DESCRIPTION
This is a baseline restructure of the Agency api to address a number of endpoint changes and incorporate feedback received in previous issue and PRs (#161 , #116  and #63 ).

Major changes:
* `provider_id` is passed as part of an authorization bearer token.
* Looking up and registering vehicles use standard `GET` and `POST` operations on `/vehicles` endpoint.
* The `/vehicles/{vehicle_id}/event` allows Providers to `POST` events to affect vehicle status.  The vehicle status is modeled around a state flow that is modeled in Vehicle Events table.
* Deregister vehicle, trip start and end are now events.
* Events for `trip_enter` and `trip_leave` were added to address trips that do not start or end in the Agency jurisdiction.