### PR TITLE
Associated Trip Fix

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -229,7 +229,7 @@ Schema: [`status_changes` schema][sc-schema]
 | `event_time` | [timestamp][ts] | Required | Date/time that event occurred, based on device clock |
 | `event_location` | GeoJSON [Point Feature][geo] | Required | |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
-| `associated_trips` | UUID[] | Optional based `event_type_reason` | Array of UUID's. For `user`-generated event types, associated trips (foreign key to Trips API) |
+| `associated_trip` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API) required if `event_type_reason` is `user_pick_up` or `user_drop_off` |
 
 ### Status Changes Query Parameters
 

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -300,6 +300,28 @@
                 }
               }
             ],
+            "anyOf": [
+              {
+                "not": {
+                  "properties": {
+                    "event_type_reason": {
+                      "enum": [
+                        "user_pick_up",
+                        "user_drop_off"
+                      ]
+                    }
+                  }
+                } 
+              },
+              {
+                "properties": {
+                  "associated_trip": {
+                    "description": "For user-generated event types, associated trip_id",
+                    "$ref": "#/definitions/uuid"
+                  }
+                }
+              }
+            ],
             "properties": {
               "provider_name": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/provider_name",
@@ -362,18 +384,6 @@
                 ],
                 "minimum": 0,
                 "maximum": 1
-              },
-              "associated_trips": {
-                "$id": "#/properties/data/properties/status_changes/items/properties/associated_trips",
-                "type": [
-                  "array",
-                  "null"
-                ],
-                "description": "For 'Reserved' event types, associated trip_ids",
-                "items": {
-                  "$id": "#/properties/data/properties/status_changes/items/properties/associated_trips/items",
-                  "$ref": "#/definitions/uuid"
-                }
               }
             }
           }


### PR DESCRIPTION
This breaking change addresses #88 for the `associated_trip` field in the `status_changes` endpoint.

Changes:
- Clarifies that associated trip is singular, not plural in provider README.md
- Modifies field name (associated_trips -> associated_trip) in JSON Schema and README.md
- Modifies JSON Schema from optional to required if applicable using implication logic
- Modifies JSON Schema type from array of UUIDs to single UUID 