### PR TITLE
Add "car" vehicle type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Mobility Data Specification
 
-The Mobility Data Specification (**MDS**) is a set of data specifications and data sharing requirements focused on dockless e-scooters and bicycles. Inspired by [GTFS](https://developers.google.com/transit/gtfs/reference/) and [GBFS](https://github.com/NABSA/gbfs) the goals of the MDS are to provide API and data standards for municipalities to help ingest, compare and analyze *mobility as a service* provider data. 
+The Mobility Data Specification (**MDS**) is a set of data specifications and data sharing requirements focused on dockless e-scooters, bicycles and cars. Inspired by [GTFS](https://developers.google.com/transit/gtfs/reference/) and [GBFS](https://github.com/NABSA/gbfs) the goals of the MDS are to provide API and data standards for municipalities to help ingest, compare and analyze *mobility as a service* provider data. 
 
-The **MDS** helps the City ingest and analyze information from for-profit companies who operate dockless scooters and bicycles in the public right-of-way. MDS is a key piece of digital infrastructure that helps cities and regulators such as Los Angeles Department of Transportation (LADOT) understand how dockless mobility operate.
+The **MDS** helps the City ingest and analyze information from for-profit companies who operate dockless scooters, bicycles and cars in the public right-of-way. MDS is a key piece of digital infrastructure that helps cities and regulators such as Los Angeles Department of Transportation (LADOT) understand how dockless mobility operate.
 
 Mobility providers are required to share data with LADOT as part of the City of Los Angeles' Dockless Mobility Permit. Standardizing data collection between different providers improves cooperation, innovation, and efficiency of the City's transportation network.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Mobility Data Specification
 
-The Mobility Data Specification (**MDS**) is a set of data specifications and data sharing requirements focused on dockless e-scooters, bicycles and cars. Inspired by [GTFS](https://developers.google.com/transit/gtfs/reference/) and [GBFS](https://github.com/NABSA/gbfs) the goals of the MDS are to provide API and data standards for municipalities to help ingest, compare and analyze *mobility as a service* provider data. 
+The Mobility Data Specification (**MDS**) is a set of data specifications and data sharing requirements focused on dockless e-scooters, bicycles and carshare. Inspired by [GTFS](https://developers.google.com/transit/gtfs/reference/) and [GBFS](https://github.com/NABSA/gbfs) the goals of the MDS are to provide API and data standards for municipalities to help ingest, compare and analyze *mobility as a service* provider data. 
 
-The **MDS** helps the City ingest and analyze information from for-profit companies who operate dockless scooters, bicycles and cars in the public right-of-way. MDS is a key piece of digital infrastructure that helps cities and regulators such as Los Angeles Department of Transportation (LADOT) understand how dockless mobility operate.
+The **MDS** helps the City ingest and analyze information from for-profit companies who operate dockless scooters, bicycles and carshare in the public right-of-way. MDS is a key piece of digital infrastructure that helps cities and regulators such as Los Angeles Department of Transportation (LADOT) understand how dockless mobility operate.
 
 Mobility providers are required to share data with LADOT as part of the City of Los Angeles' Dockless Mobility Permit. Standardizing data collection between different providers improves cooperation, innovation, and efficiency of the City's transportation network.
 

--- a/agency/README.md
+++ b/agency/README.md
@@ -298,6 +298,7 @@ A standard point of vehicle telemetry. References to latitude and longitude impl
 | `type`    |
 | --------- |
 | `bicycle` |
+| `car`     |
 | `scooter` |
 
 ### Propulsion Type

--- a/agency/get_vehicle.json
+++ b/agency/get_vehicle.json
@@ -25,6 +25,7 @@
       "description": "The type of vehicle",
       "enum": [
         "bicycle",
+        "car",
         "scooter"
       ]
     },

--- a/agency/post_vehicle.json
+++ b/agency/post_vehicle.json
@@ -25,6 +25,7 @@
       "description": "The type of vehicle",
       "enum": [
         "bicycle",
+        "car",
         "scooter"
       ]
     },

--- a/provider/README.md
+++ b/provider/README.md
@@ -217,6 +217,7 @@ When multiple query parameters are specified, they should all apply to the retur
 | `vehicle_type` |
 |--------------|
 | bicycle      |
+| car          |
 | scooter      |
 
 ### Propulsion Types

--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -171,6 +171,7 @@
       "description": "The type of vehicle",
       "enum": [
         "bicycle",
+        "car",
         "scooter"
       ]
     },

--- a/provider/dockless/trips.json
+++ b/provider/dockless/trips.json
@@ -202,6 +202,7 @@
       "description": "The type of vehicle",
       "enum": [
         "bicycle",
+        "car",
         "scooter"
       ]
     },

--- a/schema/templates/common.json
+++ b/schema/templates/common.json
@@ -57,6 +57,7 @@
       "description": "The type of vehicle",
       "enum": [
         "bicycle",
+        "car",
         "scooter"
       ]
     },


### PR DESCRIPTION
I am working with BlueLA, a car sharing service in Los Angeles. We have implemented the MDS API. 

The MDS API currently has 2 types of vehicle: `bicycle` and `scooter`. I have seen discussions about adding new types (at least #95 #167 #170) but they seem to be stale and/or related to broader subjects (and thus less actionable).

I think that "just" adding a new `car` vehicle type could be an easy and good enough first step.