### PR TITLE
Add provider: BlueLA

### DIFF
--- a/providers.csv
+++ b/providers.csv
@@ -11,3 +11,4 @@ Spin,70aa475d-1fcd-4504-b69c-2eeb2107f7be,https://www.spin.app,https://api.spin.
 WIND,d56d2df6-fa92-43de-ab61-92c3a84acd7d,https://www.wind.co,https://partners.wind.co/v1/mds,
 Tier,264aad41-b47c-415d-8585-0208d436516e,https://www.tier.app,https://partner.tier-services.io/mds,
 Cloud,bf95148b-d1d1-464e-a140-6d2563ac43d4,https://www.cloud.tt,https://mds.cloud.tt,https://mds.cloud.tt/gbfs
+BlueLA,f3c5a65d-fd85-463e-9564-fc95ea473f7d,https://www.bluela.com,https://api.bluela.com/mds/v0,https://api.bluela.com/gbfs/v1/meta


### PR DESCRIPTION
BlueLA is an electric car sharing service in Los Angeles. We have implemented the MDS API and believe we are ready for inclusion in the list of providers.

I believe that we are the first service with *cars*. Apart from the vehicle type that we obviously had to customize (we use "car" for now [1]), we've been able to successfully implement the MDS (as well as the parts of GBFS that are mandated by the MDS).

[1] Speaking of the vehicle type, I have seen discussions about that, albeit much broader (and, as such, probably less actionable). I took the liberty of proposing #219 that adds a new `car` vehicle type.