### PR TITLE
 Require each event to include a UUID

### DIFF
--- a/generate_schema/provider/status_changes.json
+++ b/generate_schema/provider/status_changes.json
@@ -36,6 +36,7 @@
               "vehicle_id",
               "vehicle_type",
               "propulsion_type",
+              "event_id",
               "event_type",
               "event_type_reason",
               "event_time",
@@ -76,6 +77,11 @@
                 "$id": "#/properties/data/properties/status_changes/items/properties/propulsion_type",
                 "description": "The type of propulsion; allows multiple values",
                 "$ref": "#/definitions/propulsion_type"
+              },
+              "event_id": {
+                "$id": "#/properties/data/properties/trips/items/properties/event_id",
+                "description": "A unique ID for each event",
+                "$ref": "#/definitions/uuid"
               },
               "event_time": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/event_time",

--- a/provider/README.md
+++ b/provider/README.md
@@ -224,6 +224,7 @@ Schema: [`status_changes` schema][sc-schema]
 | `vehicle_id` | String | Required | The Vehicle Identification Number visible on the vehicle itself |
 | `vehicle_type` | Enum | Required | see [vehicle types](#vehicle-types) table |
 | `propulsion_type` | Enum[] | Required | Array of [propulsion types](#propulsion-types); allows multiple values |
+| `event_id` | UUID | Required | A unique ID for each event |
 | `event_type` | Enum | Required | See [event types](#event-types) table |
 | `event_type_reason` | Enum | Required | Reason for status change, allowable values determined by [`event type`](#event-types) |
 | `event_time` | [timestamp][ts] | Required | Date/time that event occurred, based on device clock |

--- a/provider/README.md
+++ b/provider/README.md
@@ -50,7 +50,7 @@ The following keys must be used for pagination links:
 * `prev`: url to the previous page of data
 * `next`: url to the next page of data
 
-At a minimum, paginated payloads must include a `next` key, which must be set to `null` to indicate the last page of data. 
+At a minimum, paginated payloads must include a `next` key, which must be set to `null` to indicate the last page of data.
 
 ```json
 {
@@ -113,10 +113,10 @@ A trip represents a journey taken by a *mobility as a service* customer with a g
 
 The trips API allows a user to query historical trip data.
 
-Endpoint: `/trips`  
-Method: `GET`  
-Schema: [`trips` schema][trips-schema]  
-`data` Payload: `{ "trips": [] }`, an array of objects with the following structure  
+Endpoint: `/trips`
+Method: `GET`
+Schema: [`trips` schema][trips-schema]
+`data` Payload: `{ "trips": [] }`, an array of objects with the following structure
 
 
 | Field | Type    | Required/Optional | Comments |
@@ -211,9 +211,9 @@ The status of the inventory of vehicles available for customer use.
 
 This API allows a user to query the historical availability for a system within a time range.
 
-Endpoint: `/status_changes`  
-Method: `GET`  
-Schema: [`status_changes` schema][sc-schema]  
+Endpoint: `/status_changes`
+Method: `GET`
+Schema: [`status_changes` schema][sc-schema]
 `data` Payload: `{ "status_changes": [] }`, an array of objects with the following structure
 
 | Field | Type | Required/Optional | Comments |
@@ -293,7 +293,7 @@ Response:
 
 ## Realtime Data
 
-All MDS compatible `provider` APIs must expose a public [GBFS](https://github.com/NABSA/gbfs) feed as well. Given that GBFS hasn't fully [evolved to support dockless mobility](https://github.com/NABSA/gbfs/pull/92) yet, we follow the current guidelines in making bike information avaliable to the public. 
+All MDS compatible `provider` APIs must expose a public [GBFS](https://github.com/NABSA/gbfs) feed as well. Given that GBFS hasn't fully [evolved to support dockless mobility](https://github.com/NABSA/gbfs/pull/92) yet, we follow the current guidelines in making bike information avaliable to the public.
 
   - `gbfs.json` is always required and must contain a `feeds` property that lists all published feeds
   - `system_information.json` is always required

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -216,6 +216,7 @@
               "vehicle_id",
               "vehicle_type",
               "propulsion_type",
+              "event_id",
               "event_type",
               "event_type_reason",
               "event_time",
@@ -260,6 +261,11 @@
                 "$id": "#/properties/data/properties/status_changes/items/properties/propulsion_type",
                 "description": "The type of propulsion; allows multiple values",
                 "$ref": "#/definitions/propulsion_type"
+              },
+              "event_id": {
+                "$id": "#/properties/data/properties/trips/items/properties/event_id",
+                "description": "A unique ID for each event",
+                "$ref": "#/definitions/uuid"
               },
               "event_time": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/event_time",


### PR DESCRIPTION
Per discussion in #191, while in theory every event should be
unique for every `(provider_id, device_id, event_time)` tuple,
in practice this is not the case, for a variety of reasons. To
help facilitate data ingestion, referential integrity, and general
debugging/discussion, we're adding a required UUID column to every
status_change event.

Fixes #191