### PR TITLE
[Provider] Clarify how endpoints relate to municipality boundaries.

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -127,7 +127,19 @@ represented as a GeoJSON [`Feature`](https://tools.ietf.org/html/rfc7946#section
 }
 ```
 
+#### Intersection Operation
+For the purposes of this specification, the intersection of two geographic datatypes is defined according to the [`ST_Intersects` PostGIS operation](https://postgis.net/docs/ST_Intersects.html)
+
+    If a geometry or geography shares any portion of space then they intersect. For geography -- tolerance is 0.00001 meters (so any points that are close are considered to intersect)
+
+    Overlaps, Touches, Within all imply spatial intersection. If any of the aforementioned returns true, then the geometries also spatially intersect. Disjoint implies false for spatial intersection.
+
 [Top][toc]
+
+### Municipality Boundary
+Municipalities requiring MDS Provider API compliance should provide an unambiguous digital source for the municipality boundary. This boundary must be used when determining which data each `provider` API endpoint will include.
+
+The boundary file should be provided in Shapefile or GeoJSON format. The boundary file should be hosted online at a published address that all providers and `provider` API consumers can access and download.
 
 ### Timestamps
 
@@ -139,7 +151,9 @@ References to `timestamp` imply integer milliseconds since [Unix epoch](https://
 
 A trip represents a journey taken by a *mobility as a service* customer with a geo-tagged start and stop point.
 
-The trips API allows a user to query historical trip data.
+The trips endpoint allows a user to query historical trip data.
+
+Unless stated otherwise by the municipality, the trips endpoint must return all trips with a `route` which [intersects](#intersection-operation) with the [municipality boundary](#municipality-boundary).
 
 Endpoint: `/trips`  
 Method: `GET`  
@@ -197,7 +211,7 @@ A device may have one or more values from the `propulsion_type`, depending on th
 
 ### Routes
 
-To represent a route, MDS `provider` APIs must create a GeoJSON [`FeatureCollection`](https://tools.ietf.org/html/rfc7946#section-3.3), which includes every [observed point][geo] in the route.
+To represent a route, MDS `provider` APIs must create a GeoJSON [`FeatureCollection`](https://tools.ietf.org/html/rfc7946#section-3.3), which includes every [observed point][geo] in the route, even those which occur outside the [municipality boundary](#municipality-boundary).
 
 Routes must include at least 2 points: the start point and end point. Routes must include all possible GPS samples collected by a Provider. Providers may round the latitude and longitude to the level of precision representing the maximum accuracy of the specific measurement. For example, [a-GPS](https://en.wikipedia.org/wiki/Assisted_GPS) is accurate to 5 decimal places, [differential GPS](https://en.wikipedia.org/wiki/Differential_GPS) is generally accurate to 6 decimal places. Providers may round those readings to the appropriate number for their systems.
 
@@ -239,7 +253,11 @@ Routes must include at least 2 points: the start point and end point. Routes mus
 
 The status of the inventory of vehicles available for customer use.
 
-This API allows a user to query the historical availability for a system within a time range.
+The status changes endpoint allows a user to query the historical availability for a system within a time range.
+
+Unless stated otherwise by the municipality, this endpoint must return only those status changes with a `event_location` that [intersects](#intersection-operation) with the [municipality boundary](#municipality-boundary).
+
+> Note: As a result of this definition, consumers should query the [trips endpoint](#trips) to infer when vehicles enter or leave the municipality boundary.
 
 Endpoint: `/status_changes`  
 Method: `GET`  

--- a/provider/README.md
+++ b/provider/README.md
@@ -138,7 +138,7 @@ For the purposes of this specification, the intersection of two geographic datat
 ### Municipality Boundary
 Municipalities requiring MDS Provider API compliance should provide an unambiguous digital source for the municipality boundary. This boundary must be used when determining which data each `provider` API endpoint will include.
 
-The boundary file should be provided in Shapefile or GeoJSON format. The boundary file should be hosted online at a published address that all providers and `provider` API consumers can access and download.
+The boundary should be defined as a polygon or collection of polygons. The file defining the boundary should be provided in Shapefile or GeoJSON format and hosted online at a published address that all providers and `provider` API consumers can access and download.
 
 ### Timestamps
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -130,9 +130,8 @@ represented as a GeoJSON [`Feature`](https://tools.ietf.org/html/rfc7946#section
 #### Intersection Operation
 For the purposes of this specification, the intersection of two geographic datatypes is defined according to the [`ST_Intersects` PostGIS operation](https://postgis.net/docs/ST_Intersects.html)
 
-    If a geometry or geography shares any portion of space then they intersect. For geography -- tolerance is 0.00001 meters (so any points that are close are considered to intersect)
-
-    Overlaps, Touches, Within all imply spatial intersection. If any of the aforementioned returns true, then the geometries also spatially intersect. Disjoint implies false for spatial intersection.
+> If a geometry or geography shares any portion of space then they intersect. For geography -- tolerance is 0.00001 meters (so any points that are close are considered to intersect).<br>
+> Overlaps, Touches, Within all imply spatial intersection. If any of the aforementioned returns true, then the geometries also spatially intersect. Disjoint implies false for spatial intersection.
 
 [Top][toc]
 


### PR DESCRIPTION
In conversations and from ingesting data, it's become clear there is
ambiguity in how parties are reporting data in their MDS Provider API
implementations with respect to the boundary of the municipality they
are operating in. This commit adds some clarifications and definitions
to capture the original intent of the spec and what most cities (Santa
Monica and LA) have been expecting in this regard.