### PR TITLE
Updating schema version

### DIFF
--- a/ReleaseGuidelines.md
+++ b/ReleaseGuidelines.md
@@ -70,6 +70,8 @@ The following steps **must** be followed for **every** release of MDS:
 
 1. Ensure the [Milestone][mds-milestones] for this release is at `100%`.
 
+1. Update the [schema version regex][mds-schema-common]
+
 1. Run the schema generator to ensure the schema files are up to date:
 
    ```console
@@ -153,5 +155,6 @@ The following steps **must** be followed for **every** release of MDS:
 [mds-pr-new]: https://github.com/CityOfLosAngeles/mobility-data-specification/compare
 [mds-releases]: https://github.com/CityOfLosAngeles/mobility-data-specification/releases
 [mds-releases-new]: https://github.com/CityOfLosAngeles/mobility-data-specification/releases/new
+[mds-schema-common]: https://github.com/CityOfLosAngeles/mobility-data-specification/blob/master/generate_schema/common.json
 [mds-tags]: https://github.com/CityOfLosAngeles/mobility-data-specification/tags
 [semver]: https://semver.org/

--- a/generate_schema/common.json
+++ b/generate_schema/common.json
@@ -9,9 +9,9 @@
       "type": "string",
       "title": "The MDS Provider version this data represents",
       "examples": [
-        "0.2.0"
+        "0.3.0"
       ],
-      "pattern": "^0\\.2\\.[0-9]+$"
+      "pattern": "^0\\.3\\.[0-9]+$"
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -169,9 +169,9 @@
       "type": "string",
       "title": "The MDS Provider version this data represents",
       "examples": [
-        "0.2.0"
+        "0.3.0"
       ],
-      "pattern": "^0\\.2\\.[0-9]+$"
+      "pattern": "^0\\.3\\.[0-9]+$"
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -200,9 +200,9 @@
       "type": "string",
       "title": "The MDS Provider version this data represents",
       "examples": [
-        "0.2.0"
+        "0.3.0"
       ],
-      "pattern": "^0\\.2\\.[0-9]+$"
+      "pattern": "^0\\.3\\.[0-9]+$"
     },
     "uuid": {
       "$id": "#/definitions/uuid",


### PR DESCRIPTION
There's a step missing in the ReleaseGuidelines, and we forgot to update the schema version regex before releasing `0.3.0`. 

This updates the version and adds the step to ensure it isn't missed again.