### PR TITLE
provider, agency: event timestamps

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -145,6 +145,10 @@ _No content returned if no vehicle matching `device_id` is found._
 
 The vehicle `/event` endpoint allows the Provider to control the state of the vehicle including deregister a vehicle from the fleet.
 
+Different status changes on the same device must have different `timestamp` values. The (`timestamp`, `device_id`) pair can be seen as a unique identifier for any given status change.
+
+> Note: If a status change can only be expressed as the succession of multiple events, they can be sent with successive timestamps in order to express the order of these events.
+
 Endpoint: `/vehicles/{device_id}/event`
 Method: `POST`
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -258,6 +258,8 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 
 > Note: As a result of this definition, consumers should query the [trips endpoint](#trips) to infer when vehicles enter or leave the municipality boundary.
 
+Different status changes on the same device must have different `event_time` values. The (`event_time`, `device_id`) pair can be seen as a unique identifier for any given status change.
+
 Endpoint: `/status_changes`  
 Method: `GET`  
 Schema: [`status_changes` schema][sc-schema]  


### PR DESCRIPTION
For a given device, different events must have different timestamp.
Otherwise, the order of events and the resulting status can not be inferred by the agency.

See https://github.com/CityOfLosAngeles/mobility-data-specification/issues/272

