### PR TITLE
Initial check in of issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request---proposal.md
+++ b/.github/ISSUE_TEMPLATE/feature-request---proposal.md
@@ -14,7 +14,7 @@ A clear and concise description of what the problem is. Ex. I'm always frustrate
 A clear and concise description of what you want to happen.
 
 **Is this a breaking change**
-A breaking change would require consumers of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 
+A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 
 
 [  ] Yes, breaking
 [  ] No, not breaking

--- a/.github/ISSUE_TEMPLATE/feature-request---proposal.md
+++ b/.github/ISSUE_TEMPLATE/feature-request---proposal.md
@@ -1,0 +1,33 @@
+---
+name: Feature request / proposal
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Is this a breaking change**
+A breaking change would require consumers of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 
+
+[  ] Yes, breaking
+[  ] No, not breaking
+[  ] I'm not sure
+
+**`Provider` or `agency`**
+For which API is this feature being requested:
+[  ] `provider`
+[  ] `agency`
+[  ] both
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+**Explain pull request**
+Please provide a clear and concise reason for this pull request and the impact of the change
+
+**Is this a breaking change**
+A breaking change would require consumers of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 
+
+[  ] Yes, breaking
+[  ] No, not breaking
+[  ] I'm not sure
+
+**`Provider` or `agency`**
+Which API(s) will this pull request impact:
+[  ] `provider`
+[  ] `agency`
+[  ] both
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 Please provide a clear and concise reason for this pull request and the impact of the change
 
 **Is this a breaking change**
-A breaking change would require consumers of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 
+A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 
 
 [  ] Yes, breaking
 [  ] No, not breaking

--- a/ReleaseGuidelines.md
+++ b/ReleaseGuidelines.md
@@ -59,7 +59,7 @@ MDS operates on a six-week release cycle for both major updates (0.x) and patche
 
 **week 1 - proposals**
 
-Contributors submit proposals for inclusion in the release cycle in the form of pull requests and issues tagged with the Milestone for the upcoming release. Proposals should come with enough explanation to allow all stakeholders to understand intent and implementation strategy. |
+Contributors submit proposals for inclusion in the release cycle in the form of pull requests and issues tagged. If known, note what release you intended a proposal for in its description. Maintainers will tag appropriate pull requests and issues with the Milestone for the upcoming release. Proposals should come with enough explanation to allow all stakeholders to understand intent and implementation strategy. |
 
 **weeks 2-4 - consensus building, refinement, and implementation**
 


### PR DESCRIPTION
Per discussion on #270, this will help ensure that maintainers have the right information to tag issues and PRs with the correct milestones and labels. The information supplied about breaking/non-breaking changes will also be used to determine which release a given change should be targeted for.