### PR TITLE
Invalid telemetry data 400 res

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -197,7 +197,10 @@ Body Params:
 
 201 Success Response:
 
-_No content returned on success._
+| Field     | Type                           | Field Description                                                                                       |
+| --------- | ------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `result`  | String                         | Responds with number of successfully written telemetry data points and total number of provided points. |
+| `failures | [Telemetry](#telemetry-data)[] | Array of failed telemetry for one or more vehicles.                                                     |
 
 400 Failure Response:
 

--- a/agency/README.md
+++ b/agency/README.md
@@ -200,7 +200,7 @@ Body Params:
 | Field     | Type                           | Field Description                                                                                       |
 | --------- | ------------------------------ | ------------------------------------------------------------------------------------------------------- |
 | `result`  | String                         | Responds with number of successfully written telemetry data points and total number of provided points. |
-| `failures | [Telemetry](#telemetry-data)[] | Array of failed telemetry for one or more vehicles.                                                     |
+| `failures | [Telemetry](#telemetry-data)[] | Array of failed telemetry for zero or more vehicles (empty if all successful).                          |
 
 400 Failure Response:
 

--- a/agency/README.md
+++ b/agency/README.md
@@ -201,10 +201,11 @@ _No content returned on success._
 
 400 Failure Response:
 
-| `error`         | `error_description`              | `error_details`[]               |
-| --------------- | -------------------------------- | ------------------------------- |
-| `bad_param`     | A validation error occurred.     | Array of parameters with errors |
-| `missing_param` | A required parameter is missing. | Array of missing parameters     |
+| `error`         | `error_description`                  | `error_details`[]               |
+| --------------- | ------------------------------------ | ------------------------------- |
+| `bad_param`     | A validation error occurred.         | Array of parameters with errors |
+| `invalid_data`  | None of the provided data was valid. |                                 |
+| `missing_param` | A required parameter is missing.     | Array of missing parameters     |
 
 ## Service Areas
 


### PR DESCRIPTION
In the case that none of the provided telemetry data is valid, respond with a 400 error. In the case that at least one of the provided data points is successfully processed, respond with a 201 specifying how many data points were successful out of the total, and a list of failed points (if there are any). 