### PR TITLE
Change `event_time` definition to require correct ordering

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -289,10 +289,14 @@ Schema: [`status_changes` schema][sc-schema]
 | `propulsion_type` | Enum[] | Required | Array of [propulsion types](#propulsion-types); allows multiple values |
 | `event_type` | Enum | Required | See [event types](#event-types) table |
 | `event_type_reason` | Enum | Required | Reason for status change, allowable values determined by [`event type`](#event-types) |
-| `event_time` | [timestamp][ts] | Required | Date/time that event occurred, based on device clock |
+| `event_time` | [timestamp][ts] | Required | Date/time that event occurred at. See [Event Times](#event-times) |
 | `event_location` | GeoJSON [Point Feature][geo] | Required | |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `associated_trip` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_type_reason` is `user_pick_up` or `user_drop_off`, or for any other status change event that marks the end of a trip. |
+
+### Event Times
+
+Because of the unreliability of device clocks, the Provider is unlikely to know with total confidence what time an event occurred at. However, they are responsible for constructing as accurate a timeline as possible. Most importantly, the order of the timestamps for a particular device's events must reflect the Provider's best understanding of the order in which those events occurred.
 
 ### Status Changes Query Parameters
 


### PR DESCRIPTION
This proposal reflects the consensus of the status change ordering/uniqueness breakout group that it's reasonable to ask providers to construct an accurate and causally-consistent timeline of status
change events. This change will improve API consumers' ability to understand the ordering and timing of events in the status changes API.

See [the notes from the first breakout group call](https://groups.google.com/forum/#!topic/mds-announce/RcKFkpJ7qrA) for a little bit more context.

### Is this a breaking change

* [x] Yes, breaking
* [ ] No, not breaking
* [ ] I'm not sure

### `Provider` or `agency`

* [x] `provider`
* [ ] `agency`
* [ ] both