### PR TITLE
[0.3.x] explicitly state no ordering on data from Provider APIs

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -146,6 +146,12 @@ References to `timestamp` imply integer milliseconds since [Unix epoch](https://
 
 [Top][toc]
 
+### Order of data from Provider APIs
+
+It is not to be assumed that the order of status changes, trips, or route points pulled from Provider APIs are sorted in any order. Client code can order by `event_time` for status changes, `end_time` for trips, and `timestamp` for route points.
+
+[Top][toc]
+
 ## Trips
 
 A trip represents a journey taken by a *mobility as a service* customer with a geo-tagged start and stop point.


### PR DESCRIPTION
### `Provider` or `agency`

Which API(s) will this pull request impact:

* [x] `provider`
* [ ] `agency`
* [ ] both

### Additional context

Discussed on the MDS Provider web conference 5/9 11am PT
