### PR TITLE
Agency/Provider: change 'GPS' by 'GPS or GNSS' except field. close #309

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -266,20 +266,20 @@ The diagram below shows the expected events and related `status` transitions for
 
 ## Telemetry Data
 
-A standard point of vehicle telemetry. References to latitude and longitude imply coordinates encoded in the [WGS 84 (EPSG:4326)](https://en.wikipedia.org/wiki/World_Geodetic_System) standard GPS projection expressed as [Decimal Degrees](https://en.wikipedia.org/wiki/Decimal_degrees).
+A standard point of vehicle telemetry. References to latitude and longitude imply coordinates encoded in the [WGS 84 (EPSG:4326)](https://en.wikipedia.org/wiki/World_Geodetic_System) standard GPS or GNSS projection expressed as [Decimal Degrees](https://en.wikipedia.org/wiki/Decimal_degrees).
 
 | Field          | Type           | Required/Optional     | Field Description                                            |
 | -------------- | -------------- | --------------------- | ------------------------------------------------------------ |
 | `device_id`    | UUID           | Required              | ID used in [Register](#vehicle-register)                     |
-| `timestamp`    | Timestamp      | Required              | Date/time that event occurred. Based on GPS clock            |
+| `timestamp`    | Timestamp      | Required              | Date/time that event occurred. Based on GPS or GNSS clock            |
 | `gps`          | Object         | Required              | Telemetry position data                                      |
 | `gps.lat`      | Double         | Required              | Latitude of the location                                     |
 | `gps.lng`      | Double         | Required              | Longitude of the location                                    |
 | `gps.altitude` | Double         | Required if Available | Altitude above mean sea level in meters                      |
 | `gps.heading`  | Double         | Required if Available | Degrees - clockwise starting at 0 degrees at true North      |
 | `gps.speed`    | Float          | Required if Available | Speed in meters / sec                                        |
-| `gps.hdop`     | Float          | Required if Available | Horizontal GPS accuracy value (see [hdop](https://support.esri.com/en/other-resources/gis-dictionary/term/358112bd-b61c-4081-9679-4fca9e3eb926)) |
-| `gps.satellites` | Integer      | Required if Available | Number of GPS satellites
+| `gps.hdop`     | Float          | Required if Available | Horizontal GPS or GNSS accuracy value (see [hdop](https://support.esri.com/en/other-resources/gis-dictionary/term/358112bd-b61c-4081-9679-4fca9e3eb926)) |
+| `gps.satellites` | Integer      | Required if Available | Number of GPS or GNSS satellites
 | `charge`       | Float          | Required if Applicable | Percent battery charge of vehicle, expressed between 0 and 1 |
 
 ## Enum Definitions

--- a/agency/post_vehicle_event.json
+++ b/agency/post_vehicle_event.json
@@ -196,11 +196,11 @@
             },
             "hdop": {
               "type": "number",
-              "description": "Horizontal GPS accuracy value"
+              "description": "Horizontal GPS or GNSS accuracy value"
             },
             "satellites": {
               "type": "integer",
-              "description": "Number of GPS satellites"
+              "description": "Number of GPS or GNSS satellites"
             }
           }
         },

--- a/agency/post_vehicle_telemetry.json
+++ b/agency/post_vehicle_telemetry.json
@@ -51,11 +51,11 @@
             },
             "hdop": {
               "type": "number",
-              "description": "Horizontal GPS accuracy value"
+              "description": "Horizontal GPS or GNSS accuracy value"
             },
             "satellites": {
               "type": "integer",
-              "description": "Number of GPS satellites"
+              "description": "Number of GPS or GNSS satellites"
             }
           }
         },

--- a/generate_schema/common.json
+++ b/generate_schema/common.json
@@ -235,11 +235,11 @@
             },
             "hdop": {
               "type": "number",
-              "description": "Horizontal GPS accuracy value"
+              "description": "Horizontal GPS or GNSS accuracy value"
             },
             "satellites": {
               "type": "integer",
-              "description": "Number of GPS satellites"
+              "description": "Number of GPS or GNSS satellites"
             }
           }
         },

--- a/generate_schema/provider/status_changes.json
+++ b/generate_schema/provider/status_changes.json
@@ -84,7 +84,7 @@
               },
               "event_location": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/event_location",
-                "description": "The GPS coordinates of where the event occurred",
+                "description": "The GPS or GNSS coordinates of where the event occurred",
                 "$ref": "#/definitions/MDS_Feature_Point"
               },
               "event_type": {

--- a/provider/README.md
+++ b/provider/README.md
@@ -116,13 +116,13 @@ At a minimum, paginated payloads must include a `next` key, which must be set to
 
 ### UUIDs for Devices
 
-MDS defines the *device* as the unit that transmits GPS signals for a particular vehicle. A given device must have a UUID (`device_id` below) that is unique within the Provider's fleet.
+MDS defines the *device* as the unit that transmits GPS or GNSS signals for a particular vehicle. A given device must have a UUID (`device_id` below) that is unique within the Provider's fleet.
 
 Additionally, `device_id` must remain constant for the device's lifetime of service, regardless of the vehicle components that house the device.
 
 ### Geographic Data
 
-References to geographic datatypes (Point, MultiPolygon, etc.) imply coordinates encoded in the [WGS 84 (EPSG:4326)](https://en.wikipedia.org/wiki/World_Geodetic_System) standard GPS projection expressed as [Decimal Degrees](https://en.wikipedia.org/wiki/Decimal_degrees).
+References to geographic datatypes (Point, MultiPolygon, etc.) imply coordinates encoded in the [WGS 84 (EPSG:4326)](https://en.wikipedia.org/wiki/World_Geodetic_System) standard GPS or GNSS projection expressed as [Decimal Degrees](https://en.wikipedia.org/wiki/Decimal_degrees).
 
 Whenever an individual location coordinate measurement is presented, it must be
 represented as a GeoJSON [`Feature`](https://tools.ietf.org/html/rfc7946#section-3.2) object with a corresponding [`timestamp`][ts] property and [`Point`](https://tools.ietf.org/html/rfc7946#section-3.1.2) geometry:
@@ -228,7 +228,7 @@ A device may have one or more values from the `propulsion_type`, depending on th
 
 To represent a route, MDS `provider` APIs must create a GeoJSON [`FeatureCollection`](https://tools.ietf.org/html/rfc7946#section-3.3), which includes every [observed point][geo] in the route, even those which occur outside the [municipality boundary](#municipality-boundary).
 
-Routes must include at least 2 points: the start point and end point. Routes must include all possible GPS samples collected by a Provider. Providers may round the latitude and longitude to the level of precision representing the maximum accuracy of the specific measurement. For example, [a-GPS](https://en.wikipedia.org/wiki/Assisted_GPS) is accurate to 5 decimal places, [differential GPS](https://en.wikipedia.org/wiki/Differential_GPS) is generally accurate to 6 decimal places. Providers may round those readings to the appropriate number for their systems.
+Routes must include at least 2 points: the start point and end point. Routes must include all possible GPS or GNSS samples collected by a Provider. Providers may round the latitude and longitude to the level of precision representing the maximum accuracy of the specific measurement. For example, [a-GPS](https://en.wikipedia.org/wiki/Assisted_GPS) is accurate to 5 decimal places, [differential GPS](https://en.wikipedia.org/wiki/Differential_GPS) is generally accurate to 6 decimal places. Providers may round those readings to the appropriate number for their systems.
 
 ```js
 "route": {

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -268,7 +268,7 @@
               },
               "event_location": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/event_location",
-                "description": "The GPS coordinates of where the event occurred",
+                "description": "The GPS or GNSS coordinates of where the event occurred",
                 "$ref": "#/definitions/MDS_Feature_Point"
               },
               "event_type": {


### PR DESCRIPTION
### Explain pull request

I change every `GPS` by `GPS or GNSS` to include all [GNSS](https://en.wikipedia.org/wiki/GNSS_applications) (GLONASS, Galileo, BeiDou)
For more information you can see the issue:
#309 - GPS to GNSS (i18n)

### Is this a breaking change
No, not breaking

### `Provider` or `agency`
 both

### Additional context

To make it not breaking, I only edit the text and did not change any field.
