### PR TITLE
Update the 406 response when an invalid version is requested.

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -39,9 +39,9 @@ Content-Type: application/vnd.mds.provider+json;version=0.3
 
 > Since versioning was not added until the 0.3.0 release, if the `Content-Type` header is `application/json` or not set in the response, version `0.2` must be assumed.
 
-If an unsupported or invalid version is requested, the API must respond with a status of `406 Not Acceptable`. In which case, the response should include a body specifying a list of supported versions.
+If an unsupported or invalid version is requested, the API must respond with a status of `406 Not Acceptable`. If this occurs, a client can explicitly negotiate available versions.
 
-A client can explicitly negotiate headers using the `OPTIONS` method to an MDS endpoint. For example, to check if `trips` supports either version `0.2` or `0.3` with a preference for `0.2`, the client would issue the following request:
+A client negotiates available versions using the `OPTIONS` method to an MDS endpoint. For example, to check if `trips` supports either version `0.2` or `0.3` with a preference for `0.2`, the client would issue the following request:
 
 ```http
 OPTIONS /trips/ HTTP/1.1 


### PR DESCRIPTION
The specification has a vague statement about returning a list of available versions when the API returns a 406. Since we now have a standard way to negotiate versions, this PR updates the text to refer to that. This was discussed in the MDS provider specification meeting on 6/6/2019.

https://github.com/CityOfLosAngeles/mobility-data-specification/issues/313
