### PR TITLE
Add `publication_time` fields to trips and status changes

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -191,6 +191,7 @@ Schema: [`trips` schema][trips-schema]
 | `accuracy` | Integer | Required | The approximate level of accuracy, in meters, of `Points` within `route` |
 | `start_time` | [timestamp][ts] | Required | |
 | `end_time` | [timestamp][ts] | Required | |
+| `publication_time` | [timestamp][ts] | Optional | Date/time that trip became available through the trips endpoint |
 | `parking_verification_url` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking |
 | `standard_cost` | Integer | Optional | The cost, in cents, that it would cost to perform that trip in the standard operation of the System |
 | `actual_cost` | Integer | Optional | The actual cost, in cents, paid by the customer of the *mobility as a service* provider |
@@ -290,6 +291,7 @@ Schema: [`status_changes` schema][sc-schema]
 | `event_type` | Enum | Required | See [event types](#event-types) table |
 | `event_type_reason` | Enum | Required | Reason for status change, allowable values determined by [`event type`](#event-types) |
 | `event_time` | [timestamp][ts] | Required | Date/time that event occurred at. See [Event Times](#event-times) |
+| `publication_time` | [timestamp][ts] | Optional | Date/time that event became available through the status changes endpoint |
 | `event_location` | GeoJSON [Point Feature][geo] | Required | |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `associated_trip` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_type_reason` is `user_pick_up` or `user_drop_off`, or for any other status change event that marks the end of a trip. |

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -266,6 +266,11 @@
                 "description": "The time the event occurred, expressed as a Unix Timestamp",
                 "$ref": "#/definitions/timestamp"
               },
+              "publication_time": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/publication_time",
+                "description": "The time the event became available through the status changes endpoint, expressed as a Unix Timestamp",
+                "$ref": "#/definitions/timestamp"
+              },
               "event_location": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/event_location",
                 "description": "The GPS or GNSS coordinates of where the event occurred",

--- a/provider/trips.json
+++ b/provider/trips.json
@@ -342,6 +342,11 @@
                 "description": "The time the trip ended, expressed as a Unix Timestamp",
                 "$ref": "#/definitions/timestamp"
               },
+              "publication_time": {
+                "$id": "#/properties/data/properties/trips/items/properties/publication_time",
+                "description": "The time the trip became available through the trips endpoint, expressed as a Unix Timestamp",
+                "$ref": "#/definitions/timestamp"
+              },
               "parking_verification_url": {
                 "$id": "#/properties/data/properties/trips/items/properties/parking_verification_url",
                 "type": [

--- a/schema/templates/provider/status_changes.json
+++ b/schema/templates/provider/status_changes.json
@@ -82,6 +82,11 @@
                 "description": "The time the event occurred, expressed as a Unix Timestamp",
                 "$ref": "#/definitions/timestamp"
               },
+              "publication_time": {
+                "$id": "#/properties/data/properties/status_changes/items/properties/publication_time",
+                "description": "The time the event became available through the status changes endpoint, expressed as a Unix Timestamp",
+                "$ref": "#/definitions/timestamp"
+              },
               "event_location": {
                 "$id": "#/properties/data/properties/status_changes/items/properties/event_location",
                 "description": "The GPS or GNSS coordinates of where the event occurred",

--- a/schema/templates/provider/trips.json
+++ b/schema/templates/provider/trips.json
@@ -131,6 +131,11 @@
                 "description": "The time the trip ended, expressed as a Unix Timestamp",
                 "$ref": "#/definitions/timestamp"
               },
+              "publication_time": {
+                "$id": "#/properties/data/properties/trips/items/properties/publication_time",
+                "description": "The time the trip became available through the trips endpoint, expressed as a Unix Timestamp",
+                "$ref": "#/definitions/timestamp"
+              },
               "parking_verification_url": {
                 "$id": "#/properties/data/properties/trips/items/properties/parking_verification_url",
                 "type": ["string", "null"],


### PR DESCRIPTION
These fields will be optional in 0.3.2 and mandatory in a future version. They reflect the time that the provider made the relevant data available through the API.

This commit partially fixes #307, but it's not a complete fix since it doesn't include the ability to query by publication time.

### Is this a breaking change

 * No, not breaking

### `Provider` or `agency`

 * `provider`

### Additional context

The next minor version should make these fields mandatory and also add query params allowing clients to use them for filtering.