### PR TITLE
Specify types for Provider query parameters

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -201,10 +201,12 @@ Schema: [`trips` schema][trips-schema]
 
 The trips API should allow querying trips with a combination of query parameters.
 
-* `device_id`
-* `vehicle_id`
-* `min_end_time`: filters for trips where `end_time` occurs at or after the given time
-* `max_end_time`: filters for trips where `end_time` occurs before the given time
+| Parameter | Type | Comments |
+| ----- | ---- | -------- |
+| `device_id` | UUID | |
+| `vehicle_id` | UUID | |
+| `min_end_time` | [timestamp][ts] | filters for trips where `end_time` occurs at or after the given time |
+| `max_end_time` | [timestamp][ts] | filters for trips where `end_time` occurs before the given time|
 
 When multiple query parameters are specified, they should all apply to the returned trips. For example, a request with `?min_end_time=1549800000000&max_end_time=1549886400000` should only return trips whose end time falls in the range `[1549800000000, 1549886400000)`.
 
@@ -305,8 +307,10 @@ Because of the unreliability of device clocks, the Provider is unlikely to know 
 
 The status_changes API should allow querying status changes with a combination of query parameters.
 
-* `start_time`: filters for status changes where `event_time` occurs at or after the given time
-* `end_time`: filters for status changes where `event_time` occurs before the given time
+| Parameter | Type | Comments |
+| ----- | ---- | -------- |
+| `start_time` | [timestamp][ts] | filters for status changes where `event_time` occurs at or after the given time |
+| `end_time` | [timestamp][ts] | filters for status changes where `event_time` occurs before the given time |
 
 When multiple query parameters are specified, they should all apply to the returned status changes. For example, a request with `?start_time=1549800000000&end_time=1549886400000` should only return status changes whose `event_time` falls in the range `[1549800000000, 1549886400000)`.
 


### PR DESCRIPTION
### Introduction
Hi, I'm Zak and I joined the team at Remix a few weeks ago. I'm excited to work with the MDS community!

### Explanation
In MDS Provider it is implied that all references to timestamps should be made using `milliseconds since unix epoch`. The sections of the provider `README` for query parameters do not explicitly state types for query parameters. This change formats the explanations of query parameters to match the table specification for returned data and explicitly set types for each parameter.

### Is this a breaking change
Providers who assumed the query parameter types were ambiguous may have to update their code if they were using `seconds since unix epoch` instead of `millisconds`.

### `Provider` or `agency`?
Provider.