### PR TITLE
Allow any status change to include an `associated_trip`

### DIFF
--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -375,7 +375,7 @@
               },
               {
                 "description": "conditionally require associated_trip when applicable",
-                "oneOf": [
+                "anyOf": [
                   {
                     "not": {
                       "properties": {

--- a/schema/templates/provider/status_changes.json
+++ b/schema/templates/provider/status_changes.json
@@ -173,7 +173,7 @@
               },
               {
                 "description": "conditionally require associated_trip when applicable",
-                "oneOf": [
+                "anyOf": [
                   {
                     "not": {
                       "properties": {


### PR DESCRIPTION
PR #297 already updated the spec language to make it clear that any status change is allowed to have an `associated_trip`, but I didn't realize this was incompatible with the existing schema. The schema should now match the spec, which states that `user_pick_up` and `user_drop_off` events must have an `associated_trip` but other events may have one when applicable.

### Is this a breaking change

It's not really clear whether this should be considered a breaking change. I could see arguments either way, but I think it's moot if the intention is for this to be included in the 0.4.0 release.

### `Provider` or `agency`

`provider`