### PR TITLE
Enable providers to bucket data by fixed time windows

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -86,16 +86,12 @@ MDS defines [JSON Schema](https://json-schema.org/) files for [`trips`][trips-sc
 
 ### Pagination
 
-`provider` APIs may decide to paginate the data payload. If so, pagination must comply with the [JSON API](http://jsonapi.org/format/#fetching-pagination) specification.
+The following keys must be provided for pagination links:
 
-The following keys must be used for pagination links:
-
-* `first`: url to the first page of data
-* `last`: url to the last page of data
 * `prev`: url to the previous page of data
 * `next`: url to the next page of data
 
-At a minimum, paginated payloads must include a `next` key, which must be set to `null` to indicate the last page of data. 
+The `next` key must be set to `null` to indicate the last page of data.
 
 ```json
 {
@@ -107,13 +103,20 @@ At a minimum, paginated payloads must include a `next` key, which must be set to
         }]
     },
     "links": {
-        "first": "https://...",
-        "last": "https://...",
         "prev": "https://...",
         "next": "https://..."
     }
 }
 ```
+
+Note that depending on the specifics of how the Provider implements pagination, the number of results per page can fluctuate.
+
+As an example, consider a query for a 3 hours window to a provider that paginates by hour:
+
+`GET /trips?min_end_time=1546315200000&max_end_time=1546322400000`
+- *Page 1:* 4:00 - 5pm UTC (10 rides)
+- *Page 2:* 5:00 - 6pm UTC (0 rides)
+- *Page 3:* 6:00 - 7pm UTC (5 rides)
 
 ### UUIDs for Devices
 
@@ -201,8 +204,6 @@ Schema: [`trips` schema][trips-schema]
 
 The trips API should allow querying trips with a combination of query parameters.
 
-* `device_id`
-* `vehicle_id`
 * `min_end_time`: filters for trips where `end_time` occurs at or after the given time
 * `max_end_time`: filters for trips where `end_time` occurs before the given time
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -86,12 +86,16 @@ MDS defines [JSON Schema](https://json-schema.org/) files for [`trips`][trips-sc
 
 ### Pagination
 
-The following keys must be provided for pagination links:
+`provider` APIs may decide to paginate the data payload. If so, pagination must comply with the [JSON API](http://jsonapi.org/format/#fetching-pagination) specification.
 
+The following keys must be used for pagination links:
+
+* `first`: url to the first page of data
+* `last`: url to the last page of data
 * `prev`: url to the previous page of data
 * `next`: url to the next page of data
 
-The `next` key must be set to `null` to indicate the last page of data.
+At a minimum, paginated payloads must include a `next` key, which must be set to `null` to indicate the last page of data. 
 
 ```json
 {
@@ -103,6 +107,8 @@ The `next` key must be set to `null` to indicate the last page of data.
         }]
     },
     "links": {
+        "first": "https://...",
+        "last": "https://...",
         "prev": "https://...",
         "next": "https://..."
     }


### PR DESCRIPTION
### Background
We've seen requests from Providers to have an easier to implement Provider API.
https://github.com/CityOfLosAngeles/mobility-data-specification/issues/268

According to @johnpena:
> We've seen the latency across our API endpoints creep up on us as more agencies have adopted MDS and as more trips have been taken and added to our trips and status changes datasets.
>
> In particular, if we could present a way for a user to ask for a specific day or hour of data, it would allow us to resolve the query ahead of time and return the result to them much faster.

If Providers are able to bucket data into files of fixed time windows, and Provider API queries only touch a single bucket at a time, we can make our response times super fast! 💨 

### Proposal
This PR adds some restrictions/clarifications into MDS querying behavior that will allow Providers to bucket data into fixed time windows, and have efficient "single file" lookups under the hood.

**Remove ability to query by `vehicle_id` or `device_id`**
It's difficult to search using these fields if our data is solely indexed by time window. From the discussion in https://github.com/CityOfLosAngeles/mobility-data-specification/issues/268 it sounds like it isn't really used.

**Add clarifying language that the number of results per page may vary, or even be zero.**
This isn't technically a breaking change, but I thought it would be valuable to indicate that if providers bucket data by time window then certain buckets may not contain data, or the amount of data may vary.

### Is this a breaking change

Yes, but hopefully with limited impact given my understanding of current Provider API usage.

### `Provider` or `agency`

Which API(s) will this pull request impact:

 * `provider`

### Additional context

Add any other context or screenshots about the feature request here.
