### PR TITLE
Adding min and max values for GPS coordinates in common JSON schema

### DIFF
--- a/agency/post_vehicle_event.json
+++ b/agency/post_vehicle_event.json
@@ -176,11 +176,15 @@
           "properties": {
             "lat": {
               "type": "number",
-              "description": "Latitude of the location"
+              "description": "Latitude of the location",
+              "minimum": -90,
+              "maximum": 90
             },
             "lng": {
               "type": "number",
-              "description": "Longitude of the location"
+              "description": "Longitude of the location",
+              "minimum": -180,
+              "maximum": 180
             },
             "altitude": {
               "type": "number",

--- a/agency/post_vehicle_telemetry.json
+++ b/agency/post_vehicle_telemetry.json
@@ -31,11 +31,15 @@
           "properties": {
             "lat": {
               "type": "number",
-              "description": "Latitude of the location"
+              "description": "Latitude of the location",
+              "minimum": -90,
+              "maximum": 90
             },
             "lng": {
               "type": "number",
-              "description": "Longitude of the location"
+              "description": "Longitude of the location",
+              "minimum": -180,
+              "maximum": 180
             },
             "altitude": {
               "type": "number",

--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -22,9 +22,19 @@
         "coordinates": {
           "type": "array",
           "minItems": 2,
-          "items": {
-            "type": "number"
-          }
+          "items": [
+            {
+              "type": "number",
+              "minimum": -180.0,
+              "maximum": 180.0
+            },
+            {
+              "type": "number",
+              "minimum": -90.0,
+              "maximum": 90.0
+            }
+          ],
+          "maxItems": 2
         },
         "bbox": {
           "type": "array",

--- a/provider/dockless/trips.json
+++ b/provider/dockless/trips.json
@@ -22,9 +22,19 @@
         "coordinates": {
           "type": "array",
           "minItems": 2,
-          "items": {
-            "type": "number"
-          }
+          "items": [
+            {
+              "type": "number",
+              "minimum": -180.0,
+              "maximum": 180.0
+            },
+            {
+              "type": "number",
+              "minimum": -90.0,
+              "maximum": 90.0
+            }
+          ],
+          "maxItems": 2
         },
         "bbox": {
           "type": "array",

--- a/schema/generate_schema.py
+++ b/schema/generate_schema.py
@@ -25,6 +25,20 @@ def get_point_schema():
     # Modify some metadata
     point.pop("$schema")
     point["$id"] = get_definition(POINT)
+    # enforce lat/lon bounds
+    point["properties"]["coordinates"]["maxItems"] = 2
+    point["properties"]["coordinates"]["items"] = [
+        {
+          "type": "number",
+          "minimum": -180.0,
+          "maximum": 180.0
+        },
+        {
+           "type": "number",
+           "minimum": -90.0,
+           "maximum": 90.0
+        }
+    ]
     return point
 
 def get_multipolygon_schema():

--- a/schema/templates/common.json
+++ b/schema/templates/common.json
@@ -215,11 +215,15 @@
           "properties": {
             "lat": {
               "type": "number",
-              "description": "Latitude of the location"
+              "description": "Latitude of the location",
+              "minimum": -90,
+              "maximum": 90
             },
             "lng": {
               "type": "number",
-              "description": "Longitude of the location"
+              "description": "Longitude of the location",
+              "minimum": -180,
+              "maximum": 180
             },
             "altitude": {
               "type": "number",
@@ -314,8 +318,8 @@
       "$id": "#/definitions/timestamp",
       "title": "Integer milliseconds since Unix epoch",
       "type": "number",
-      "multipleOf": 1.0, 
-      "minimum": 0 
+      "multipleOf": 1.0,
+      "minimum": 0
     }
   }
 }


### PR DESCRIPTION
### Explain pull request

Several telemetry fields lack input validation supported by json-schema. Currently, the API will accept invalid GPS coordinates. 

This change restricts telemetry GPS latitude and longitude values to be valid coordinates of [-90,90] for latitude and [-180,180] for longitude. JSON validation can reject malformed GPS coordinates rather than propagate bad data.

### Is this a breaking change

This is a **non-breaking change for code**.

It is a potentially **breaking change for legacy bad data** with invalid GPS coordinates. That's ultimately the intent. City agencies will need to assess whether there is a practical impact based on the quality of existing data.

### `Provider` or `agency`

This pull request impacts the **Agency API's** vehicle event and telemetry POST endpoints.

