### PR TITLE
Allow static file data storage for Provider /status_changes and /trips

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -230,6 +230,8 @@ Schema: [`trips` schema][trips-schema]
 
 The trips API should allow querying trips with the following query parameters. 
 
+Without an `end_time` query parameter, `/trips` shall return an error. 
+
 * `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing an Hour. Timezone UTC. 
 
 | Request range | format | expected output | 
@@ -342,6 +344,8 @@ The status_changes API should allow querying status changes with a combination o
 | Request range | format | expected output | 
 | ------------- | ------ | --------------- | 
 | Hour          | YYYY-MM-DD:HH | That hour worth of status changes, or if the hour is not complete or the file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denotated as the next day's zero hour. | 
+
+Without an `end_time` query parameter, `/status_changes` shall return an error. 
 
 ### Event Types
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -342,15 +342,15 @@ Because of the unreliability of device clocks, the Provider is unlikely to know 
 
 ### Status Changes Query Parameters
 
-The status_changes API should allow querying status changes with a combination of query parameters.
+The `/status_changes` API should allow querying status changes with the following query parameters:
 
-* `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing a hour. The response will have all status changes whose event time occurred within the hour. For example, if you requested "2019-10-01T07", you should get back all status that happened between `7:00 <= and < 8:00`.Timezone UTC. 
+| Parameter | Format | Expected Output |
+| --------------- | ------ | --------------- |
+| `event_time` | `YYYY-MM-DDTHH`, an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended datetime representing an UTC hour between 00 and 23. | All status changes with an event time occurring within the hour. For example, requesting `event_time=2019-10-01T07` returns all status changes where `07:00 <= trip.end_time < 08:00` on October 01, 2019 UTC. |
 
-| Request range | format | expected output | 
-| ------------- | ------ | --------------- | 
-| Hour          | YYYY-MM-DDTHH | That hour worth of status changes, or if the hour is not complete or the file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denoted as the next day's zero hour. | 
+If the data does not exist or the hour has not completed, `/status_changes` shall return a `404 Not Found` error.
 
-Without an `end_time` query parameter, `/status_changes` shall return an error. 
+Without an `event_time` query parameter, `/status_changes` shall return a `400 Bad Request` error.
 
 ### Event Types
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -252,15 +252,15 @@ Schema: [`trips` schema][trips-schema]
 
 ### Trips Query Parameters
 
-The trips API should allow querying trips with the following query parameters. 
+The `/trips` API should allow querying trips with the following query parameters:
 
-Without an `end_time` query parameter, `/trips` shall return an error. 
+| Parameter | Format | Expected Output |
+| --------------- | ------ | --------------- |
+| `end_time` | `YYYY-MM-DDTHH`, an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended datetime representing an UTC hour between 00 and 23. | All trips with an end time occurring within the hour. For example, requesting `end_time=2019-10-01T07` returns all trips where `07:00 <= trip.end_time < 08:00` on October 01, 2019 UTC. |
 
-* `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing an Hour. The response will have all trips whose end time occurred in the hour. For example, if you requested "2019-10-01T07", you should get back all trips that ended between `7:00 <= and < 8:00`. Timezone UTC. 
+If the data does not exist or the hour has not completed, `/trips` shall return a `404 Not Found` error.
 
-| Request range | format | expected output | 
-| ------------- | ------ | --------------- | 
-| Hour          | YYYY-MM-DDTHH | That hour worth of trips, or if the hour is not complete or the file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denoted as the next day's zero hour. | 
+Without an `end_time` query parameter, `/trips` shall return a `400 Bad Request` error.
 
 For the near-ish real time use cases, please use the [events](#events) endpoint. 
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -337,19 +337,11 @@ Because of the unreliability of device clocks, the Provider is unlikely to know 
 
 The status_changes API should allow querying status changes with a combination of query parameters.
 
-* `start_time`: filters for status changes where `event_time` occurs at or after the given time
-* `end_time`: filters for status changes where `event_time` occurs before the given time
-* `static_end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing either a Month, Day, or Hour. Timezone UTC. 
+* `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing a hour. Timezone UTC. 
 
 | Request range | format | expected output | 
 | ------------- | ------ | --------------- | 
-| Month         | YYYY-DD | That month's worth of status changes, or if the month is not complete or the file does not exist , an error | 
-| Day           | YYYY-MM-DD | That day's worth of status changes, or if the day is not complete or the file does not exist, an error | 
-| Hour          | YYYY-MM-DD:HH | That hour worth of status changes, or if the hour is not complete or hte file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denotated as the next day's zero hour. | 
-
-The `min_end_time` and `max_end_time` endpoints shall not be used in combination with the `static_end_time` endpoints, rather, the the former is good for real-ish time uses cases, while the latter is best for reconstructing the historical record and backfilling. It is considered permissive to return an incorrect query parameter responses for the `min_end_time`  / `max_end_time` if the range contains timestamps older than one month. 
-
-When multiple query parameters are specified, they should all apply to the returned status changes. For example, a request with `?start_time=1549800000000&end_time=1549886400000` should only return status changes whose `event_time` falls in the range `[1549800000000, 1549886400000)`.
+| Hour          | YYYY-MM-DD:HH | That hour worth of status changes, or if the hour is not complete or the file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denotated as the next day's zero hour. | 
 
 ### Event Types
 
@@ -382,6 +374,8 @@ All MDS compatible `provider` APIs must expose a public [GBFS](https://github.co
   - `station_information.json` and `station_status.json` don't apply for MDS
 
 ### Events
+
+The events endpoint is a near-ish real time feed of events, designed to give access to as recent as possible series of events from the vehicle feed. It functions similarly to status chan
 
 [Top][toc]
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -375,7 +375,36 @@ All MDS compatible `provider` APIs must expose a public [GBFS](https://github.co
 
 ### Events
 
-The events endpoint is a near-ish real time feed of events, designed to give access to as recent as possible series of events from the vehicle feed. It functions similarly to status chan
+The events endpoint is a near-ish real time feed of events, designed to give access to as recent as possible series of events from the vehicle feed. It functions similarly to status changes, but shall not included data older than 2 weeks (that should live in `/status_changes.`)
+
+Unless stated otherwise by the municipality, this endpoint must return only those events with a `event_location` that [intersects](#intersection-operation) with the [municipality boundary](#municipality-boundary).
+
+> Note: As a result of this definition, consumers should query the [trips endpoint](#trips) to infer when vehicles enter or leave the municipality boundary.
+
+The datatype and scheme are the same as `status_changes
+
+Endpoint: `/events`  
+Method: `GET`  
+Schema: [`status_changes` schema][sc-schema]  
+`data` Payload: `{ "status_changes": [] }`, an array of objects with the following structure
+
+### Event Times
+
+Because of the unreliability of device clocks, the Provider is unlikely to know with total confidence what time an event occurred at. However, they are responsible for constructing as accurate a timeline as possible. Most importantly, the order of the timestamps for a particular device's events must reflect the Provider's best understanding of the order in which those events occurred.
+
+### Events Query Parameters
+
+The events API should allow querying status changes with a combination of query parameters.
+
+| Parameter | Type | Comments |
+| ----- | ---- | -------- |
+| `start_time` | [timestamp][ts] | filters for status changes where `event_time` occurs at or after the given time |
+| `end_time` | [timestamp][ts] | filters for status changes where `event_time` occurs before the given time |
+
+When multiple query parameters are specified, they should all apply to the returned status changes. For example, a request with `?start_time=1549800000000&end_time=1549886400000` should only return status changes whose `event_time` falls in the range `[1549800000000, 1549886400000)`.
+
+Should the requested time range be greater than 2 weeks old, the API shall return an error. 
+
 
 [Top][toc]
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -407,12 +407,12 @@ Because of the unreliability of device clocks, the Provider is unlikely to know 
 
 The events API should allow querying with a combination of query parameters:
 
-| Parameter | Type | Comments |
+| Parameter | Type | Expected Output |
 | ----- | ---- | -------- |
-| `start_time` | [timestamp][ts] | filters for status changes where `event_time` occurs at or after the given time |
-| `end_time` | [timestamp][ts] | filters for status changes where `event_time` occurs before the given time |
+| `start_time` | [timestamp][ts] | status changes where `start_time <= status_change.event_time` |
+| `end_time` | [timestamp][ts] | status changes where `status_change.event_time < end_time` |
 
-When multiple query parameters are specified, they should all apply to the returned status changes. For example, a request with `?start_time=1549800000000&end_time=1549886400000` should only return status changes where `1549800000000 <= status_change.event_time < 1549886400000`.
+Should either side of the requested time range be missing, the API shall return a `400 Bad Request` error.
 
 Should either side of the requested time range be greater than 2 weeks before the time of the request, the API shall return a `400 Bad Request` error.
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -343,7 +343,7 @@ The status_changes API should allow querying status changes with a combination o
 
 | Request range | format | expected output | 
 | ------------- | ------ | --------------- | 
-| Hour          | YYYY-MM-DD:HH | That hour worth of status changes, or if the hour is not complete or the file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denotated as the next day's zero hour. | 
+| Hour          | YYYY-MM-DD:HH | That hour worth of status changes, or if the hour is not complete or the file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denoted as the next day's zero hour. | 
 
 Without an `end_time` query parameter, `/status_changes` shall return an error. 
 
@@ -385,7 +385,7 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 
 > Note: As a result of this definition, consumers should query the [trips endpoint](#trips) to infer when vehicles enter or leave the municipality boundary.
 
-The datatype and scheme are the same as `status_changes
+The datatype and scheme are the same as `status_changes`.
 
 Endpoint: `/events`  
 Method: `GET`  

--- a/provider/README.md
+++ b/provider/README.md
@@ -232,11 +232,11 @@ The trips API should allow querying trips with the following query parameters.
 
 Without an `end_time` query parameter, `/trips` shall return an error. 
 
-* `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing an Hour. The response will have all trips whose end time occurred in the hour. For example, if you requested "2019-10-01:07", you should get back all trips that ended between `7:00 <= and < 8:00`. Timezone UTC. 
+* `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing an Hour. The response will have all trips whose end time occurred in the hour. For example, if you requested "2019-10-01T07", you should get back all trips that ended between `7:00 <= and < 8:00`. Timezone UTC. 
 
 | Request range | format | expected output | 
 | ------------- | ------ | --------------- | 
-| Hour          | YYYY-MM-DD:HH | That hour worth of trips, or if the hour is not complete or the file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denoted as the next day's zero hour. | 
+| Hour          | YYYY-MM-DDTHH | That hour worth of trips, or if the hour is not complete or the file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denoted as the next day's zero hour. | 
 
 For the near-ish real time use cases, please use the [events](#events) endpoint. 
 
@@ -339,11 +339,11 @@ Because of the unreliability of device clocks, the Provider is unlikely to know 
 
 The status_changes API should allow querying status changes with a combination of query parameters.
 
-* `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing a hour. The response will have all status changes whose event time occurred within the hour. For example, if you requested "2019-10-01:07", you should get back all status that happened between `7:00 <= and < 8:00`.Timezone UTC. 
+* `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing a hour. The response will have all status changes whose event time occurred within the hour. For example, if you requested "2019-10-01T07", you should get back all status that happened between `7:00 <= and < 8:00`.Timezone UTC. 
 
 | Request range | format | expected output | 
 | ------------- | ------ | --------------- | 
-| Hour          | YYYY-MM-DD:HH | That hour worth of status changes, or if the hour is not complete or the file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denoted as the next day's zero hour. | 
+| Hour          | YYYY-MM-DDTHH | That hour worth of status changes, or if the hour is not complete or the file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denoted as the next day's zero hour. | 
 
 Without an `end_time` query parameter, `/status_changes` shall return an error. 
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -403,7 +403,7 @@ The events API should allow querying status changes with a combination of query 
 
 When multiple query parameters are specified, they should all apply to the returned status changes. For example, a request with `?start_time=1549800000000&end_time=1549886400000` should only return status changes whose `event_time` falls in the range `[1549800000000, 1549886400000)`.
 
-Should the requested time range be greater than 2 weeks old, the API shall return an error. 
+Should the requested time range be greater than 2 weeks old, the API shall return a 400 bad request error. 
 
 
 [Top][toc]

--- a/provider/README.md
+++ b/provider/README.md
@@ -230,14 +230,15 @@ The trips API should allow querying trips with a combination of query parameters
 
 * `min_end_time`: filters for trips where `end_time` occurs at or after the given time
 * `max_end_time`: filters for trips where `end_time` occurs before the given time
-* `static_end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing either a Month, Day, or Hour. 
+* `static_end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing either a Month, Day, or Hour. Timezone UTC. 
 
 | Request range | format | expected output | 
 | ------------- | ------ | --------------- | 
-| Month         | YYYY-DD | The month worth of data, or if the month is not complete or the file does not exist , an error | 
-| Day           | YYYY-MM-DD | That day worth of   
-When multiple query parameters are specified, they should all apply to the returned trips. For example, a request with `?min_end_time=1549800000000&max_end_time=1549886400000` should only return trips whose end time falls in the range `[1549800000000, 1549886400000)`.
+| Month         | YYYY-DD | That month's worth of trips, or if the month is not complete or the file does not exist , an error | 
+| Day           | YYYY-MM-DD | That day's worth of trips, or if the day is not complete or the file does not exist, an error | 
+| Hour          | YYYY-MM-DD:HH | That hour worth of trips, or if the hour is not complete or hte file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denotated as the next day's zero hour. | 
 
+The `min_end_time` and `max_end_time` endpoints shall not be used in combination with the `static_end_time` endpoints, rather, the the former is good for real-ish time uses cases, while the latter is best for reconstructing the historical record and backfilling. It is considered permissive to return an incorrect query parameter responses for the `min_end_time`  / `max_end_time` if the range contains timestamps older than one month. 
 ### Vehicle Types
 
 | `vehicle_type` |
@@ -337,10 +338,17 @@ Because of the unreliability of device clocks, the Provider is unlikely to know 
 
 The status_changes API should allow querying status changes with a combination of query parameters.
 
-| Parameter | Type | Comments |
-| ----- | ---- | -------- |
-| `start_time` | [timestamp][ts] | filters for status changes where `event_time` occurs at or after the given time |
-| `end_time` | [timestamp][ts] | filters for status changes where `event_time` occurs before the given time |
+* `start_time`: filters for status changes where `event_time` occurs at or after the given time
+* `end_time`: filters for status changes where `event_time` occurs before the given time
+* `static_end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing either a Month, Day, or Hour. Timezone UTC. 
+
+| Request range | format | expected output | 
+| ------------- | ------ | --------------- | 
+| Month         | YYYY-DD | That month's worth of status changes, or if the month is not complete or the file does not exist , an error | 
+| Day           | YYYY-MM-DD | That day's worth of status changes, or if the day is not complete or the file does not exist, an error | 
+| Hour          | YYYY-MM-DD:HH | That hour worth of status changes, or if the hour is not complete or hte file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denotated as the next day's zero hour. | 
+
+The `min_end_time` and `max_end_time` endpoints shall not be used in combination with the `static_end_time` endpoints, rather, the the former is good for real-ish time uses cases, while the latter is best for reconstructing the historical record and backfilling. It is considered permissive to return an incorrect query parameter responses for the `min_end_time`  / `max_end_time` if the range contains timestamps older than one month. 
 
 When multiple query parameters are specified, they should all apply to the returned status changes. For example, a request with `?start_time=1549800000000&end_time=1549886400000` should only return status changes whose `event_time` falls in the range `[1549800000000, 1549886400000)`.
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -232,7 +232,7 @@ The trips API should allow querying trips with the following query parameters.
 
 Without an `end_time` query parameter, `/trips` shall return an error. 
 
-* `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing an Hour. Timezone UTC. 
+* `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing an Hour. The response will have all trips whose end time occurred in the hour. For example, if you requested "2019-10-01:07", you should get back all trips that ended between `7:00 <= and < 8:00`. Timezone UTC. 
 
 | Request range | format | expected output | 
 | ------------- | ------ | --------------- | 
@@ -339,7 +339,7 @@ Because of the unreliability of device clocks, the Provider is unlikely to know 
 
 The status_changes API should allow querying status changes with a combination of query parameters.
 
-* `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing a hour. Timezone UTC. 
+* `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing a hour. The response will have all status changes whose event time occurred within the hour. For example, if you requested "2019-10-01:07", you should get back all status that happened between `7:00 <= and < 8:00`.Timezone UTC. 
 
 | Request range | format | expected output | 
 | ------------- | ------ | --------------- | 

--- a/provider/README.md
+++ b/provider/README.md
@@ -8,8 +8,8 @@ This specification contains a data standard for *mobility as a service* provider
 * [Trips](#trips)
 * [Status Changes](#status-changes)
 * [Realtime Data](#realtime-data)
-    - [GBFS](#GBFS)
-    - [Events](#events)
+  - [GBFS](#GBFS)
+  - [Events](#events)
 
 ## General Information
 
@@ -179,6 +179,7 @@ For the purposes of this specification, the intersection of two geographic datat
 [Top][toc]
 
 ### Municipality Boundary
+
 Municipalities requiring MDS Provider API compliance should provide an unambiguous digital source for the municipality boundary. This boundary must be used when determining which data each `provider` API endpoint will include.
 
 The boundary should be defined as a polygon or collection of polygons. The file defining the boundary should be provided in Shapefile or GeoJSON format and hosted online at a published address that all providers and `provider` API consumers can access and download.
@@ -188,6 +189,29 @@ Providers are not required to recalculate the set of historical data that is inc
 ### Timestamps
 
 References to `timestamp` imply integer milliseconds since [Unix epoch](https://en.wikipedia.org/wiki/Unix_time). You can find the implementation of unix timestamp in milliseconds for your programming language [here](https://currentmillis.com/).
+
+### Vehicle Types
+
+The list of allowed `vehicle_type` referenced below is:
+
+| `vehicle_type` |
+|--------------|
+| bicycle      |
+| car          |
+| scooter      |
+
+### Propulsion Types
+
+The list of allowed `propulsion_type` referenced below is:
+
+| `propulsion_type` | Description |
+| ----------------- | ----------------- |
+| human           | Pedal or foot propulsion |
+| electric_assist | Provides power only alongside human propulsion |
+| electric        | Contains throttle mode with a battery-powered motor |
+| combustion      | Contains throttle mode with a gas engine-powered motor |
+
+A device may have one or more values from the `propulsion_type`, depending on the number of modes of operation. For example, a scooter that can be powered by foot or by electric motor would have the `propulsion_type` represented by the array `['human', 'electric']`. A bicycle with pedal-assist would have the `propulsion_type` represented by the array `['human', 'electric_assist']` if it can also be operated as a traditional bicycle.
 
 [Top][toc]
 
@@ -239,25 +263,6 @@ Without an `end_time` query parameter, `/trips` shall return an error.
 | Hour          | YYYY-MM-DDTHH | That hour worth of trips, or if the hour is not complete or the file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denoted as the next day's zero hour. | 
 
 For the near-ish real time use cases, please use the [events](#events) endpoint. 
-
-### Vehicle Types
-
-| `vehicle_type` |
-|--------------|
-| bicycle      |
-| car          |
-| scooter      |
-
-### Propulsion Types
-
-| `propulsion_type` | Description |
-| ----------------- | ----------------- |
-| human           | Pedal or foot propulsion |
-| electric_assist | Provides power only alongside human propulsion |
-| electric        | Contains throttle mode with a battery-powered motor |
-| combustion      | Contains throttle mode with a gas engine-powered motor |
-
-A device may have one or more values from the `propulsion_type`, depending on the number of modes of operation. For example, a scooter that can be powered by foot or by electric motor would have the `propulsion_type` represented by the array `['human', 'electric']`. A bicycle with pedal-assist would have the `propulsion_type` represented by the array `['human', 'electric_assist']` if it can also be operated as a traditional bicycle.
 
 ### Routes
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -228,13 +228,14 @@ Schema: [`trips` schema][trips-schema]
 
 The trips API should allow querying trips with a combination of query parameters.
 
-| Parameter | Type | Comments |
-| ----- | ---- | -------- |
-| `device_id` | UUID | |
-| `vehicle_id` | UUID | |
-| `min_end_time` | [timestamp][ts] | filters for trips where `end_time` occurs at or after the given time |
-| `max_end_time` | [timestamp][ts] | filters for trips where `end_time` occurs before the given time|
+* `min_end_time`: filters for trips where `end_time` occurs at or after the given time
+* `max_end_time`: filters for trips where `end_time` occurs before the given time
+* `static_end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing either a Month, Day, or Hour. 
 
+| Request range | format | expected output | 
+| ------------- | ------ | --------------- | 
+| Month         | YYYY-DD | The month worth of data, or if the month is not complete or the file does not exist , an error | 
+| Day           | YYYY-MM-DD | That day worth of   
 When multiple query parameters are specified, they should all apply to the returned trips. For example, a request with `?min_end_time=1549800000000&max_end_time=1549886400000` should only return trips whose end time falls in the range `[1549800000000, 1549886400000)`.
 
 ### Vehicle Types

--- a/provider/README.md
+++ b/provider/README.md
@@ -346,7 +346,7 @@ The `/status_changes` API should allow querying status changes with the followin
 
 | Parameter | Format | Expected Output |
 | --------------- | ------ | --------------- |
-| `event_time` | `YYYY-MM-DDTHH`, an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended datetime representing an UTC hour between 00 and 23. | All status changes with an event time occurring within the hour. For example, requesting `event_time=2019-10-01T07` returns all status changes where `07:00 <= trip.end_time < 08:00` on October 01, 2019 UTC. |
+| `event_time` | `YYYY-MM-DDTHH`, an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended datetime representing an UTC hour between 00 and 23. | All status changes with an event time occurring within the hour. For example, requesting `event_time=2019-10-01T07` returns all status changes where `07:00 <= status_change.event_time < 08:00` on October 01, 2019 UTC. |
 
 If the data does not exist or the hour has not completed, `/status_changes` shall return a `404 Not Found` error.
 
@@ -397,7 +397,7 @@ The schema and datatypes are the same as those defined for [`/status_changes`][s
 Endpoint: `/events`  
 Method: `GET`  
 Schema: [`status_changes` schema][sc-schema]  
-`data` Payload: `{ "status_changes": [] }`, an array of objects with the same structure as [`/status_changes`][status]
+`data` Payload: `{ "status_changes": [] }`, an array of objects with the same structure as in [`/status_changes`][status]
 
 ### Event Times
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -384,18 +384,20 @@ All MDS compatible `provider` APIs must expose a public [GBFS](https://github.co
 
 ### Events
 
-The events endpoint is a near-ish real time feed of events, designed to give access to as recent as possible series of events from the vehicle feed. It functions similarly to status changes, but shall not included data older than 2 weeks (that should live in `/status_changes.`)
+The `/events` endpoint is a near-ish real-time feed of status changes, designed to give access to as recent as possible series of events.
 
-Unless stated otherwise by the municipality, this endpoint must return only those events with a `event_location` that [intersects](#intersection-operation) with the [municipality boundary](#municipality-boundary).
+The `/events` endpoint functions similarly to `/status_changes`, but shall not included data older than 2 weeks (that should live in `/status_changes.`)
+
+Unless stated otherwise by the municipality, this endpoint must return only those events with an `event_location` that [intersects](#intersection-operation) with the [municipality boundary](#municipality-boundary).
 
 > Note: As a result of this definition, consumers should query the [trips endpoint](#trips) to infer when vehicles enter or leave the municipality boundary.
 
-The datatype and scheme are the same as `status_changes`.
+The schema and datatypes are the same as those defined for [`/status_changes`][status].
 
 Endpoint: `/events`  
 Method: `GET`  
 Schema: [`status_changes` schema][sc-schema]  
-`data` Payload: `{ "status_changes": [] }`, an array of objects with the following structure
+`data` Payload: `{ "status_changes": [] }`, an array of objects with the same structure as [`/status_changes`][status]
 
 ### Event Times
 
@@ -403,22 +405,22 @@ Because of the unreliability of device clocks, the Provider is unlikely to know 
 
 ### Events Query Parameters
 
-The events API should allow querying status changes with a combination of query parameters.
+The events API should allow querying with a combination of query parameters:
 
 | Parameter | Type | Comments |
 | ----- | ---- | -------- |
 | `start_time` | [timestamp][ts] | filters for status changes where `event_time` occurs at or after the given time |
 | `end_time` | [timestamp][ts] | filters for status changes where `event_time` occurs before the given time |
 
-When multiple query parameters are specified, they should all apply to the returned status changes. For example, a request with `?start_time=1549800000000&end_time=1549886400000` should only return status changes whose `event_time` falls in the range `[1549800000000, 1549886400000)`.
+When multiple query parameters are specified, they should all apply to the returned status changes. For example, a request with `?start_time=1549800000000&end_time=1549886400000` should only return status changes where `1549800000000 <= status_change.event_time < 1549886400000`.
 
-Should the requested time range be greater than 2 weeks old, the API shall return a 400 bad request error. 
-
+Should either side of the requested time range be greater than 2 weeks before the time of the request, the API shall return a `400 Bad Request` error.
 
 [Top][toc]
 
 [geo]: #geographic-data
 [sc-schema]: status_changes.json
+[status]: #status-changes
 [toc]: #table-of-contents
 [trips-schema]: trips.json
 [ts]: #timestamps

--- a/provider/README.md
+++ b/provider/README.md
@@ -8,6 +8,8 @@ This specification contains a data standard for *mobility as a service* provider
 * [Trips](#trips)
 * [Status Changes](#status-changes)
 * [Realtime Data](#realtime-data)
+    - [GBFS](#GBFS)
+    - [Events](#events)
 
 ## General Information
 
@@ -226,19 +228,16 @@ Schema: [`trips` schema][trips-schema]
 
 ### Trips Query Parameters
 
-The trips API should allow querying trips with a combination of query parameters.
+The trips API should allow querying trips with the following query parameters. 
 
-* `min_end_time`: filters for trips where `end_time` occurs at or after the given time
-* `max_end_time`: filters for trips where `end_time` occurs before the given time
-* `static_end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing either a Month, Day, or Hour. Timezone UTC. 
+* `end_time`: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date for a static bucket of files representing an Hour. Timezone UTC. 
 
 | Request range | format | expected output | 
 | ------------- | ------ | --------------- | 
-| Month         | YYYY-DD | That month's worth of trips, or if the month is not complete or the file does not exist , an error | 
-| Day           | YYYY-MM-DD | That day's worth of trips, or if the day is not complete or the file does not exist, an error | 
-| Hour          | YYYY-MM-DD:HH | That hour worth of trips, or if the hour is not complete or hte file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denotated as the next day's zero hour. | 
+| Hour          | YYYY-MM-DD:HH | That hour worth of trips, or if the hour is not complete or the file does not exist, an error. The minimum value of the hour should be 00 and the max 23, as the midnight hour should be denoted as the next day's zero hour. | 
 
-The `min_end_time` and `max_end_time` endpoints shall not be used in combination with the `static_end_time` endpoints, rather, the the former is good for real-ish time uses cases, while the latter is best for reconstructing the historical record and backfilling. It is considered permissive to return an incorrect query parameter responses for the `min_end_time`  / `max_end_time` if the range contains timestamps older than one month. 
+For the near-ish real time use cases, please use the [events](#events) endpoint. 
+
 ### Vehicle Types
 
 | `vehicle_type` |
@@ -373,12 +372,16 @@ When multiple query parameters are specified, they should all apply to the retur
 
 ## Realtime Data
 
+### GBFS
+
 All MDS compatible `provider` APIs must expose a public [GBFS](https://github.com/NABSA/gbfs) feed as well. Given that GBFS hasn't fully [evolved to support dockless mobility](https://github.com/NABSA/gbfs/pull/92) yet, we follow the current guidelines in making bike information avaliable to the public. 
 
   - `gbfs.json` is always required and must contain a `feeds` property that lists all published feeds
   - `system_information.json` is always required
   - `free_bike_status.json` is required for MDS
   - `station_information.json` and `station_status.json` don't apply for MDS
+
+### Events
 
 [Top][toc]
 


### PR DESCRIPTION
### Explain pull request

In #268, @johnpena discusses the need to make MDS queries more predictable. @babldev attempted to address the issue in #354, but during the discussion on 9-4, it sounded like folks wanted a different type of solution. 

This builds on #354 and specifically @hyperknot's suggestion that we split the possible response with different query parameters. 

It introduces `static_end_time` to both `/trips` and `/status_changes`. This would be an ISO month, day, or hour that could be cached on S3 or a similar static file store that could be returned as a single page or set of pages. 

TBH, adding this complexity makes me want to also finish the openAPI work so that this can be made more clearly and testable by providers and clients alike. I'll take a stab at that shortly, but would love folks thoughts on this. 
### Is this a breaking change

A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 

 * Yes, breaking

### `Provider` or `agency`

Which API(s) will this pull request impact:

 * `provider`

### Additional context

Fixes #268.
Fixes #350.
Fixes #385.