### PR TITLE
Add string limit length of 255

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -28,6 +28,10 @@ When making requests, the Agency API expects `provider_id` to be part of the cla
 
 As with the Provider API, `timestamp` refers to integer milliseconds since Unix epoch. 
 
+## Strings
+
+All String fields, such as `vehicle_id`, are limited to a maximum of 255 characters.
+
 ## Vehicles
 
 The `/vehicles` endpoint returns the specified vehicle (if a device_id is provided) or a list of known vehicles.  Providers can only retrieve data for vehicles in their registered fleet.

--- a/agency/get_vehicle.json
+++ b/agency/get_vehicle.json
@@ -38,6 +38,7 @@
         "inactive",
         "removed",
         "reserved",
+        "trip",
         "unavailable"
       ]
     },
@@ -231,6 +232,7 @@
     "vehicle_id": {
       "$id": "#/properties/vehicle_id",
       "type": "string",
+      "maxLength": 255,
       "description": "The Vehicle Identification Number visible on the vehicle itself",
       "default": "",
       "examples": [
@@ -260,6 +262,7 @@
     "mfgr": {
       "$id": "#/properties/mfgr",
       "type": "string",
+      "maxLength": 255,
       "description": "The vehicle manufacturer",
       "default": "",
       "examples": [
@@ -270,6 +273,7 @@
     "model": {
       "$id": "#/properties/model",
       "type": "string",
+      "maxLength": 255,
       "description": "The vehicle model",
       "default": "",
       "examples": [

--- a/agency/post_vehicle.json
+++ b/agency/post_vehicle.json
@@ -54,6 +54,7 @@
     "vehicle_id": {
       "$id": "#/properties/vehicle_id",
       "type": "string",
+      "maxLength": 255,
       "description": "The Vehicle Identification Number visible on the vehicle itself",
       "default": "",
       "examples": [
@@ -83,6 +84,7 @@
     "mfgr": {
       "$id": "#/properties/mfgr",
       "type": "string",
+      "maxLength": 255,
       "description": "The vehicle manufacturer",
       "default": "",
       "examples": [
@@ -93,6 +95,7 @@
     "model": {
       "$id": "#/properties/model",
       "type": "string",
+      "maxLength": 255,
       "description": "The vehicle model",
       "default": "",
       "examples": [

--- a/schema/templates/agency/get_vehicle.json
+++ b/schema/templates/agency/get_vehicle.json
@@ -31,6 +31,7 @@
     "vehicle_id": {
       "$id": "#/properties/vehicle_id",
       "type": "string",
+      "maxLength": 255,
       "description": "The Vehicle Identification Number visible on the vehicle itself",
       "default": "",
       "examples": [
@@ -60,6 +61,7 @@
     "mfgr": {
       "$id": "#/properties/mfgr",
       "type": "string",
+      "maxLength": 255,
       "description": "The vehicle manufacturer",
       "default": "",
       "examples": [
@@ -70,6 +72,7 @@
     "model": {
       "$id": "#/properties/model",
       "type": "string",
+      "maxLength": 255,
       "description": "The vehicle model",
       "default": "",
       "examples": [

--- a/schema/templates/agency/post_vehicle.json
+++ b/schema/templates/agency/post_vehicle.json
@@ -19,6 +19,7 @@
     "vehicle_id": {
       "$id": "#/properties/vehicle_id",
       "type": "string",
+      "maxLength": 255,
       "description": "The Vehicle Identification Number visible on the vehicle itself",
       "default": "",
       "examples": [
@@ -48,6 +49,7 @@
     "mfgr": {
       "$id": "#/properties/mfgr",
       "type": "string",
+      "maxLength": 255,
       "description": "The vehicle manufacturer",
       "default": "",
       "examples": [
@@ -58,6 +60,7 @@
     "model": {
       "$id": "#/properties/model",
       "type": "string",
+      "maxLength": 255,
       "description": "The vehicle model",
       "default": "",
       "examples": [

--- a/schema/templates/common.json
+++ b/schema/templates/common.json
@@ -48,6 +48,7 @@
         "inactive",
         "removed",
         "reserved",
+        "trip",
         "unavailable"
       ]
     },


### PR DESCRIPTION
### Explain pull request

Per #348:

> Is there a plan to add a field size limitation? For example, the device_id or vehicle_id could be limited in their number of characters.

### Is this a breaking change

 * No, not breaking

### `Provider` or `agency`

Which API(s) will this pull request impact:

 * `agency`

### Additional context

Add any other context or screenshots about the feature request here.
