### PR TITLE
Unify error response format per #317

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -75,6 +75,31 @@ Response bodies must be a `UTF-8` encoded JSON object and must minimally include
 }
 ```
 
+#### Provider HTTP Codes
+
+* **200:** OK: operation successful.
+* **400:** Bad request.
+* **401:** Unauthorized: Invalid, expired, or insufficient scope of token.
+* **404:** Not Found: Object(s) do not exist.
+* **500:** Internal server error.
+
+#### Error Format
+
+```json
+{
+    "version": "x.y.z",
+    "error": "...",
+    "error_description": "...",
+    "error_details": [ "...", "..." ]
+}
+```
+
+| Field               | Type     | Field Description      |
+| ------------------- | -------- | ---------------------- |
+| `error`             | String   | Error message string   |
+| `error_description` | String   | Human readable error description (can be localized) |
+| `error_details`     | String[] (optional) | Array of error details |
+
 All response fields must use `lower_case_with_underscores`.
 
 #### JSON Schema

--- a/provider/README.md
+++ b/provider/README.md
@@ -75,7 +75,7 @@ Response bodies must be a `UTF-8` encoded JSON object and must minimally include
 }
 ```
 
-#### Provider HTTP Codes
+#### HTTP Response Codes
 
 * **200:** OK: operation successful.
 * **400:** Bad request.
@@ -87,7 +87,6 @@ Response bodies must be a `UTF-8` encoded JSON object and must minimally include
 
 ```json
 {
-    "version": "x.y.z",
     "error": "...",
     "error_description": "...",
     "error_details": [ "...", "..." ]


### PR DESCRIPTION
### Explain pull request

From #317 

> Adopt same error responses as for Agency API

### Is this a breaking change

 * No, not breaking

### `Provider` or `agency`

Which API(s) will this pull request impact:

 * `provider`

### Additional context

Nothing immediately comes to mind