### PR TITLE
Clarify municipality boundary geofiltering for historical data (#355)

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -157,6 +157,8 @@ Municipalities requiring MDS Provider API compliance should provide an unambiguo
 
 The boundary should be defined as a polygon or collection of polygons. The file defining the boundary should be provided in Shapefile or GeoJSON format and hosted online at a published address that all providers and `provider` API consumers can access and download.
 
+Providers are not required to recalculate the set of historical data that is included when the municipality boundary changes. All new data must use the updated municipality boundary.
+
 ### Timestamps
 
 References to `timestamp` imply integer milliseconds since [Unix epoch](https://en.wikipedia.org/wiki/Unix_time). You can find the implementation of unix timestamp in milliseconds for your programming language [here](https://currentmillis.com/).


### PR DESCRIPTION
### Explain pull request

#226 clarified precisely what data providers are expected to return through the API, by requiring an unambiguous geography boundary:

> Municipalities requiring MDS Provider API compliance should provide an unambiguous digital source for the municipality boundary. This boundary must be used when determining which data each provider API endpoint will include.

> The boundary should be defined as a polygon or collection of polygons. The file defining the boundary should be provided in Shapefile or GeoJSON format and hosted online at a published address that all providers and provider API consumers can access and download.

The wording here could be interpreted to mean that providers need to apply the latest version of this municipality boundary to all queries. This interpretation prevents providers from performing optimizations like pre-processing and storing flat files for faster access (see #354).

This adds a couple of sentences to clarify the intent of the municipality boundary filtering. Specifically, it explicitly does not require historical reprocessing of data when the boundary changes.

### Is this a breaking change

 * No, not breaking

### `Provider` or `agency`

Which API(s) will this pull request impact:

 * `provider`
