### PR TITLE
Remove SLA verbiage from /telemetry endpoint

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -183,9 +183,6 @@ Body Params:
 
 The vehicle `/telemetry` endpoint allows a Provider to send vehicle telemetry data in a batch for any number of vehicles in the fleet.
 
-The Update Telemetry endpoint (/telemetry) shall be called for the specific trip within 24 hrs after the vehicle trip is over.   
-For any given trip, data reported via the (/telemetry) endpoint shall contain temporal and location data for every 300 ft (91 meters) while vehicle is in motion and 30 seconds while at rest. For Mobility Service Providers who do not calculate distance in real-time, a periodic rate of 14 seconds can be used while vehicle is in motion.
-
 Endpoint: `/vehicles/telemetry`
 Method: `POST`
 


### PR DESCRIPTION
The paragraph specifying latency and time/space resolution should never have been included in the spec.  Such requirements are policy decisions that should be adjudicated by regulating agencies.

### Explain pull request

Remove paragraph

### Is this a breaking change

 * No, not breaking

### `Provider` or `agency`

Which API(s) will this pull request impact:

 * `agency`

### Additional context

None