### PR TITLE
Update ReleaseGuidelines.md with meeting info

### DIFF
--- a/ReleaseGuidelines.md
+++ b/ReleaseGuidelines.md
@@ -7,6 +7,7 @@ MDS will see regular updates and new [releases][mds-releases]. This document des
 * [Versioning](#versioning)
 * [Release Process](#process)
   * [Goals](#goals)
+  * [Project Meetings](#project-meetings)
   * [Roles](#roles)
   * [Schedule](#schedule)
   * [Communication and Workflow](#communication-and-workflow)
@@ -53,6 +54,10 @@ The sections below define the release process itself, including timeline, roles,
 
 >**It is our intent to maintain a level of coordination between the technical direction of `agency` and `provider`. As such, proposed changes to either API will be reviewed to ensure they do not create unnecessary duplicative functionality, introduce confusion about which API should be used for a given purpose, or prevent the reconciliation of data between the two APIs (for example: using data from `provider` to cross-validate data received via `agency`).**
 
+### Project Meetings
+* Web conference and in person work sessions will posted to the [google calendar XXXXX](). Meetings generally occur monthly.
+* The meeting organizer can use the [meeting template](https://github.com/CityOfLosAngeles/mobility-data-specification/wiki/Web-Conference-Template) to prepare for project meetings. Use the [template markup code](https://github.com/CityOfLosAngeles/mobility-data-specification/wiki/Web-Conference-Template/_edit) to create the next scheduled wiki meeting page before the meeting. Include the how to join the meeting and agenda details. Posting the agenda before the meeting has the added benefit that project contributors can propose agenda items.
+
 ### Goals
 
 * _Fast, regular releases to support rapid evolution of MDS_
@@ -64,7 +69,6 @@ The sections below define the release process itself, including timeline, roles,
 * _Frequent stakeholder communication on GitHub, web conference, and in-person_
 
 * _Regular review of release process to ensure it is serving the needs of the community._
-
 
 ### Roles
 * **contributors** - Anyone making pull requests, opening issues, or engaging in technical discussion around implementation of features.


### PR DESCRIPTION
### Explain pull request

As per issue https://github.com/CityOfLosAngeles/mobility-data-specification/issues/364

I will need to add the meeting calendar URL to the PR before this can be merged.

### Is this a breaking change

 * No, not breaking

### `Provider` or `agency`

Which API(s) will this pull request impact:

 * None

### Additional context

None
