### PR TITLE
Adding a /vehicles endpoint to show the current status of the fleet

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -434,7 +434,7 @@ ttl                 | Yes       | Integer representing the number of millisecond
 | `last_event_type` | Enum | Required | Event type of most recent status change. See [event types](#event-types) table |
 | `last_event_type_reason` | Enum | Required | Event type reason of most recent status change, allowable values determined by [`event type`](#event-types) |
 | `last_event_location` | GeoJSON [Point Feature][geo]| Required | Location of vehicle's last event |
-| `current_location` | GeoJSON [Point Feature][geo] | Required | Current location of vehicle if different from last event, and the vehicle is not currently on a trip |
+| `current_location` | GeoJSON [Point Feature][geo] | Required if Applicable | Current location of vehicle if different from last event, and the vehicle is not currently on a trip |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 
 [Top][toc]

--- a/provider/README.md
+++ b/provider/README.md
@@ -420,6 +420,7 @@ ttl                 | Yes       | Integer representing the number of millisecond
 **Endpoint:** `/vehicles`  
 **Method:** `GET`  
 **Required/Optional:** Optional starting with `0.4.1`, moving to Required in a future version (`0.5.0`+)  
+**Schema:** [`vehicles` schema][vehicles-schema]  
 **`data` Payload:** `{ "vehicles": [] }`, an array of objects with the following structure
 
 | Field | Type | Required/Optional | Comments |
@@ -441,8 +442,9 @@ ttl                 | Yes       | Integer representing the number of millisecond
 
 [general-information/versioning]: /general-information.md#versioning
 [geo]: #geographic-data
-[sc-schema]: status_changes.json
+[sc-schema]: dockless/status_changes.json
 [status]: #status-changes
 [toc]: #table-of-contents
-[trips-schema]: trips.json
+[trips-schema]: dockless/trips.json
 [ts]: #timestamps
+[vehicles-schema]: dockless/vehicles.json

--- a/provider/README.md
+++ b/provider/README.md
@@ -392,13 +392,22 @@ Should either side of the requested time range be missing, `/events` shall retur
 
 Should either side of the requested time range be greater than 2 weeks before the time of the request, `/events` shall return a `400 Bad Request` error.
 
-All providers should provide an endpoint that displays the current status of the fleet. Data in this endpoint should reconcile with data from the status changes enpdoint.
-
 ### Vehicles
+
+All providers should provide an endpoint that displays the current status of the fleet. Data in this endpoint should reconcile with data from the status changes enpdoint.
 
 Endpoint: `/vehicles`  
 Method: `GET`   
-`data` Payload: `{ "vehicles": [] }`, an array of objects with the following structure
+
+The response should contain header information that indicates when it was last updated and when it will be updated again
+
+Field Name          | Required  | Defines
+--------------------| ----------| ----------
+last_updated        | Yes       | Timestamp indicating the last time the data in this feed was updated
+ttl                 | Yes       | Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)
+
+
+`data` Payload: `{ "last_updated": , "ttl": ,"vehicles": [] }`, an array of objects with the following structure
 
 | Field | Type | Required/Optional | Comments |
 | ----- | ---- | ----------------- | ----- |

--- a/provider/README.md
+++ b/provider/README.md
@@ -396,17 +396,29 @@ Should either side of the requested time range be greater than 2 weeks before th
 
 All providers should provide an endpoint that displays the current status of the fleet. Data in this endpoint should reconcile with data from the status changes enpdoint.
 
-Endpoint: `/vehicles`  
-Method: `GET`   
+In addition to the standard [Provider payload wrapper](#response-format), responses from this endpoint should contain the last update timestamp and amount of time until the next update:
 
-The response should contain header information that indicates when it was last updated and when it will be updated again
+```json
+{
+    "version": "x.y.z",
+    "data": {
+        "vehicles": []
+    },
+    "last_updated": "12345",
+    "ttl": "12345"
+}
+```
+
+Where `last_updated` and `ttl` are defined as follows:
 
 Field Name          | Required  | Defines
 --------------------| ----------| ----------
 last_updated        | Yes       | Timestamp indicating the last time the data in this feed was updated
-ttl                 | Yes       | Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)
+ttl                 | Yes       | Integer representing the number of milliseconds before the data in this feed will be updated again (0 if the data should always be refreshed)
 
-`data` Payload: `{ "last_updated": , "ttl": ,"vehicles": [] }`, an array of objects with the following structure
+Endpoint: `/vehicles`
+Method: `GET`
+`data` Payload: `{ "vehicles": [] }`, an array of objects with the following structure
 
 | Field | Type | Required/Optional | Comments |
 | ----- | ---- | ----------------- | ----- |

--- a/provider/README.md
+++ b/provider/README.md
@@ -392,6 +392,25 @@ Should either side of the requested time range be missing, `/events` shall retur
 
 Should either side of the requested time range be greater than 2 weeks before the time of the request, `/events` shall return a `400 Bad Request` error.
 
+All providers should provide an endpoint that displays the current status of the fleet. Data in this endpoint should reconcile with data from the status changes enpdoint.
+
+Endpoint: `/vehicles`  
+Method: `GET`   
+`data` Payload: `{ "vehicles": [] }`, an array of objects with the following structure
+
+| Field | Type | Required/Optional | Comments |
+| ----- | ---- | ----------------- | ----- |
+| `device_id` | UUID | Required | A unique device ID in UUID format |
+| `vehicle_id` | String | Required | The Vehicle Identification Number visible on the vehicle itself |
+| `vehicle_type` | Enum | Required | see [vehicle types](#vehicle-types) table |
+| `propulsion_type` | Enum[] | Required | Array of [propulsion types](#propulsion-types); allows multiple values |
+| `last_event_time` | [timestamp][ts] | Required | Date/time that last status change occurred at. See [Event Times](#event-times) |
+| `last_event_type` | Enum | Required | See [event types](#event-types) table |
+| `last_event_type_reason` | Enum | Required | Reason for status change, allowable values determined by [`event type`](#event-types) |
+| `last_event_location` | GeoJSON [Point Feature][geo]| Required | Location of veicle's last event |
+| `current_location` | GeoJSON [Point Feature][geo] | Optional | Current loaction of vehicle if different from last event |
+| `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
+
 [Top][toc]
 
 [general-information/versioning]: /general-information.md#versioning

--- a/provider/README.md
+++ b/provider/README.md
@@ -416,9 +416,10 @@ Field Name          | Required  | Defines
 last_updated        | Yes       | Timestamp indicating the last time the data in this feed was updated
 ttl                 | Yes       | Integer representing the number of milliseconds before the data in this feed will be updated again (0 if the data should always be refreshed).
 
-Endpoint: `/vehicles`
-Method: `GET`
-`data` Payload: `{ "vehicles": [] }`, an array of objects with the following structure
+**Endpoint:** `/vehicles`  
+**Method:** `GET`  
+**Required/Optional:** Optional starting with `0.4.1`, moving to Required in a future version (`0.5.0`+)  
+**`data` Payload:** `{ "vehicles": [] }`, an array of objects with the following structure
 
 | Field | Type | Required/Optional | Comments |
 | ----- | ---- | ----------------- | ----- |

--- a/provider/README.md
+++ b/provider/README.md
@@ -431,7 +431,7 @@ Method: `GET`
 | `last_event_time` | [timestamp][ts] | Required | Date/time when last status change occurred. See [Event Times](#event-times) |
 | `last_event_type` | Enum | Required | Event type of most recent status change. See [event types](#event-types) table |
 | `last_event_type_reason` | Enum | Required | Event type reason of most recent status change, allowable values determined by [`event type`](#event-types) |
-| `last_event_location` | GeoJSON [Point Feature][geo]| Required | Location of veicle's last event |
+| `last_event_location` | GeoJSON [Point Feature][geo]| Required | Location of vehicle's last event |
 | `current_location` | GeoJSON [Point Feature][geo] | Required | Current location of vehicle if different from last event, and the vehicle is not currently on a trip |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -402,13 +402,13 @@ Method: `GET`
 
 | Field | Type | Required/Optional | Comments |
 | ----- | ---- | ----------------- | ----- |
-| `device_id` | UUID | Required | A unique device ID in UUID format |
-| `vehicle_id` | String | Required | The Vehicle Identification Number visible on the vehicle itself |
+| `device_id` | UUID | Required | A unique device ID in UUID format, should match this device in Provider |
+| `vehicle_id` | String | Required | The Vehicle Identification Number visible on the vehicle itself, should match this device in provider |
 | `vehicle_type` | Enum | Required | see [vehicle types](#vehicle-types) table |
 | `propulsion_type` | Enum[] | Required | Array of [propulsion types](#propulsion-types); allows multiple values |
-| `last_event_time` | [timestamp][ts] | Required | Date/time that last status change occurred at. See [Event Times](#event-times) |
-| `last_event_type` | Enum | Required | See [event types](#event-types) table |
-| `last_event_type_reason` | Enum | Required | Reason for status change, allowable values determined by [`event type`](#event-types) |
+| `last_event_time` | [timestamp][ts] | Required | Date/time when last status change occurred. See [Event Times](#event-times) |
+| `last_event_type` | Enum | Required | Event type of most recent status change. See [event types](#event-types) table |
+| `last_event_type_reason` | Enum | Required | Event type reason of most recent status change, allowable values determined by [`event type`](#event-types) |
 | `last_event_location` | GeoJSON [Point Feature][geo]| Required | Location of veicle's last event |
 | `current_location` | GeoJSON [Point Feature][geo] | Optional | Current loaction of vehicle if different from last event |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |

--- a/provider/README.md
+++ b/provider/README.md
@@ -394,6 +394,8 @@ Should either side of the requested time range be greater than 2 weeks before th
 
 All providers should provide an endpoint that displays the current status of the fleet. Data in this endpoint should reconcile with data from the status changes enpdoint.
 
+### Vehicles
+
 Endpoint: `/vehicles`  
 Method: `GET`   
 `data` Payload: `{ "vehicles": [] }`, an array of objects with the following structure

--- a/provider/README.md
+++ b/provider/README.md
@@ -394,7 +394,7 @@ Should either side of the requested time range be greater than 2 weeks before th
 
 ### Vehicles
 
-All providers should provide an endpoint that displays the current status of a providers vehicles on the PROW. Only vehicles that are currently in available, unavailable, or reserved states should be returned in this payload. Data in this endpoint should reconcile with data from the status changes enpdoint. This data should be refreshed at most every 5 minutes.
+The `/vehicles` endpoint returns the current status of vehicles on the PROW. Only vehicles that are currently in available, unavailable, or reserved states should be returned in this payload. Data in this endpoint should reconcile with data from the `/status_changes` enpdoint. The data returned by this endpoint should be as close to realtime as possible, but in no case should it be more than 5 minutes out-of-date.
 
 In addition to the standard [Provider payload wrapper](#response-format), responses from this endpoint should contain the last update timestamp and amount of time until the next update:
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -394,7 +394,7 @@ Should either side of the requested time range be greater than 2 weeks before th
 
 ### Vehicles
 
-All providers should provide an endpoint that displays the current status of the fleet. Data in this endpoint should reconcile with data from the status changes enpdoint.
+All providers should provide an endpoint that displays the current status of a providers vehicles on the PROW. Only vehicles that are currently in available, unavailable, or reserved states should be returned in this payload. Data in this endpoint should reconcile with data from the status changes enpdoint. This data should be refreshed at most every 5 minutes.
 
 In addition to the standard [Provider payload wrapper](#response-format), responses from this endpoint should contain the last update timestamp and amount of time until the next update:
 
@@ -414,7 +414,7 @@ Where `last_updated` and `ttl` are defined as follows:
 Field Name          | Required  | Defines
 --------------------| ----------| ----------
 last_updated        | Yes       | Timestamp indicating the last time the data in this feed was updated
-ttl                 | Yes       | Integer representing the number of milliseconds before the data in this feed will be updated again (0 if the data should always be refreshed)
+ttl                 | Yes       | Integer representing the number of milliseconds before the data in this feed will be updated again (0 if the data should always be refreshed).
 
 Endpoint: `/vehicles`
 Method: `GET`

--- a/provider/README.md
+++ b/provider/README.md
@@ -10,6 +10,7 @@ This specification contains a data standard for *mobility as a service* provider
 * [Realtime Data](#realtime-data)
   * [GBFS](#GBFS)
   * [Events](#events)
+  * [Vehicles](#vehicles)
 
 ## General Information
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -432,7 +432,7 @@ Method: `GET`
 | `last_event_type` | Enum | Required | Event type of most recent status change. See [event types](#event-types) table |
 | `last_event_type_reason` | Enum | Required | Event type reason of most recent status change, allowable values determined by [`event type`](#event-types) |
 | `last_event_location` | GeoJSON [Point Feature][geo]| Required | Location of veicle's last event |
-| `current_location` | GeoJSON [Point Feature][geo] | Optional | Current loaction of vehicle if different from last event |
+| `current_location` | GeoJSON [Point Feature][geo] | Required | Current location of vehicle if different from last event, and the vehicle is not currently on a trip |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 
 [Top][toc]

--- a/provider/README.md
+++ b/provider/README.md
@@ -406,11 +406,12 @@ Field Name          | Required  | Defines
 last_updated        | Yes       | Timestamp indicating the last time the data in this feed was updated
 ttl                 | Yes       | Integer representing the number of seconds before the data in this feed will be updated again (0 if the data should always be refreshed)
 
-
 `data` Payload: `{ "last_updated": , "ttl": ,"vehicles": [] }`, an array of objects with the following structure
 
 | Field | Type | Required/Optional | Comments |
 | ----- | ---- | ----------------- | ----- |
+| `provider_id` | UUID | Required | A UUID for the Provider, unique within MDS |
+| `provider_name` | String | Required | The public-facing name of the Provider |
 | `device_id` | UUID | Required | A unique device ID in UUID format, should match this device in Provider |
 | `vehicle_id` | String | Required | The Vehicle Identification Number visible on the vehicle itself, should match this device in provider |
 | `vehicle_type` | Enum | Required | see [vehicle types](#vehicle-types) table |

--- a/provider/dockless/vehicles.json
+++ b/provider/dockless/vehicles.json
@@ -359,23 +359,6 @@
                     ]
                   }
                 }
-              },
-              {
-                "properties": {
-                  "last_event_type": {
-                    "enum": [
-                      "removed"
-                    ]
-                  },
-                  "last_event_type_reason": {
-                    "enum": [
-                      "service_end",
-                      "rebalance_pick_up",
-                      "maintenance_pick_up",
-                      "agency_pick_up"
-                    ]
-                  }
-                }
               }
             ]
           }

--- a/provider/dockless/vehicles.json
+++ b/provider/dockless/vehicles.json
@@ -1,0 +1,404 @@
+{
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/vehicles.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Provider Schema, vehicles payload",
+  "type": "object",
+  "definitions": {
+    "Point": {
+      "$id": "#/definitions/Point",
+      "title": "GeoJSON Point",
+      "type": "object",
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Point"
+          ]
+        },
+        "coordinates": {
+          "type": "array",
+          "minItems": 2,
+          "items": [
+            {
+              "type": "number",
+              "minimum": -180.0,
+              "maximum": 180.0
+            },
+            {
+              "type": "number",
+              "minimum": -90.0,
+              "maximum": 90.0
+            }
+          ],
+          "maxItems": 2
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "MDS_Feature_Point": {
+      "$id": "#/definitions/MDS_Feature_Point",
+      "title": "MDS GeoJSON Feature Point",
+      "type": "object",
+      "required": [
+        "type",
+        "properties",
+        "geometry"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Feature"
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "required": [
+            "timestamp"
+          ],
+          "properties": {
+            "timestamp": {
+              "$ref": "#/definitions/timestamp"
+            }
+          }
+        },
+        "geometry": {
+          "$ref": "#/definitions/Point"
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "links": {
+      "$id": "#/definitions/links",
+      "type": "object",
+      "required": [
+        "next"
+      ],
+      "properties": {
+        "first": {
+          "$id": "#/definitions/links/first",
+          "type": [
+            "null",
+            "string"
+          ],
+          "title": "The URL to the first page of data",
+          "examples": [
+            "https://data.provider.co/trips/first"
+          ],
+          "format": "uri"
+        },
+        "last": {
+          "$id": "#/definitions/links/last",
+          "type": [
+            "null",
+            "string"
+          ],
+          "title": "The URL to the last page of data",
+          "examples": [
+            "https://data.provider.co/trips/last"
+          ],
+          "format": "uri"
+        },
+        "prev": {
+          "$id": "#/definitions/links/prev",
+          "type": [
+            "null",
+            "string"
+          ],
+          "title": "The URL to the previous page of data",
+          "examples": [
+            "https://data.provider.co/trips/prev"
+          ],
+          "format": "uri"
+        },
+        "next": {
+          "$id": "#/definitions/links/next",
+          "type": [
+            "null",
+            "string"
+          ],
+          "title": "The URL to the next page of data",
+          "examples": [
+            "https://data.provider.co/trips/next"
+          ],
+          "format": "uri",
+          "pattern": "^(.*)$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "propulsion_type": {
+      "$id": "#/definitions/propulsion_type",
+      "type": "array",
+      "description": "The type of propulsion; allows multiple values",
+      "items": {
+        "type": "string",
+        "enum": [
+          "combustion",
+          "electric",
+          "electric_assist",
+          "human"
+        ]
+      },
+      "minItems": 1
+    },
+    "timestamp": {
+      "$id": "#/definitions/timestamp",
+      "title": "Integer milliseconds since Unix epoch",
+      "type": "number",
+      "multipleOf": 1.0,
+      "minimum": 0
+    },
+    "vehicle_type": {
+      "$id": "#/definitions/vehicle_type",
+      "type": "string",
+      "description": "The type of vehicle",
+      "enum": [
+        "bicycle",
+        "car",
+        "scooter",
+        "moped"
+      ]
+    },
+    "version": {
+      "$id": "#/definitions/version",
+      "type": "string",
+      "title": "The MDS Provider version this data represents",
+      "examples": [
+        "0.4.0"
+      ],
+      "pattern": "^0\\.4\\.[0-9]+$"
+    },
+    "uuid": {
+      "$id": "#/definitions/uuid",
+      "type": "string",
+      "title": "A UUID used to uniquely identifty an object",
+      "default": "",
+      "examples": [
+        "3c9604d6-b5ee-11e8-96f8-529269fb1459"
+      ],
+      "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+    }
+  },
+  "required": [
+    "version",
+    "data",
+    "last_updated",
+    "ttl"
+  ],
+  "properties": {
+    "version": {
+      "$id": "#/properties/version",
+      "$ref": "#/definitions/version"
+    },
+    "data": {
+      "$id": "#/properties/data",
+      "type": "object",
+      "title": "The page of data",
+      "required": [
+        "vehicles"
+      ],
+      "properties": {
+        "vehicles": {
+          "$id": "#/properties/data/properties/vehicles",
+          "type": "array",
+          "title": "The vehicles Schema",
+          "items": {
+            "$id": "#/properties/data/properties/vehicles/items",
+            "type": "object",
+            "title": "The vehicles items Schema",
+            "required": [
+              "provider_name",
+              "provider_id",
+              "device_id",
+              "vehicle_id",
+              "vehicle_type",
+              "propulsion_type",
+              "last_event_time",
+              "last_event_type",
+              "last_event_type_reason",
+              "last_event_location"
+            ],
+            "properties": {
+              "provider_name": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/provider_name",
+                "type": "string",
+                "description": "The public-facing name of the Provider",
+                "examples": [
+                  "Provider Name"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "provider_id": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/provider_id",
+                "description": "The UUID for the Provider, unique within MDS",
+                "$ref": "#/definitions/uuid"
+              },
+              "device_id": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/device_id",
+                "description": "A unique device ID in UUID format",
+                "$ref": "#/definitions/uuid"
+              },
+              "vehicle_id": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/vehicle_id",
+                "type": "string",
+                "description": "The Vehicle Identification Number visible on the vehicle itself",
+                "default": "",
+                "examples": [
+                  "ABC123"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "vehicle_type": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/vehicle_type",
+                "$ref": "#/definitions/vehicle_type",
+                "description": "The type of vehicle"
+              },
+              "propulsion_type": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/propulsion_type",
+                "description": "The type of propulsion; allows multiple values",
+                "$ref": "#/definitions/propulsion_type"
+              },
+              "last_event_time": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/last_event_time",
+                "description": "The time the most recent status change event occurred, expressed as a Unix Timestamp",
+                "$ref": "#/definitions/timestamp"
+              },
+              "last_event_type": {
+                "type": "string",
+                "description": "The type of the event"
+              },
+              "last_event_type_reason": {
+                "type": "string",
+                "description": "The reason for the event"
+              },
+              "last_event_location": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/last_event_location",
+                "description": "Location of the vehicle's last status change event",
+                "$ref": "#/definitions/MDS_Feature_Point"
+              },
+              "current_location": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/current_location",
+                "description": "Current location of vehicle if different from last event, and the vehicle is not currently on a trip",
+                "$ref": "#/definitions/MDS_Feature_Point"
+              },
+              "battery_pct": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/battery_pct",
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Percent charge of device battery, expressed between 0 and 1",
+                "examples": [
+                  0.89
+                ],
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "oneOf": [
+              {
+                "properties": {
+                  "last_event_type": {
+                    "enum": [
+                      "available"
+                    ]
+                  },
+                  "last_event_type_reason": {
+                    "enum": [
+                      "service_start",
+                      "user_drop_off",
+                      "rebalance_drop_off",
+                      "maintenance_drop_off",
+                      "agency_drop_off"
+                    ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "last_event_type": {
+                    "enum": [
+                      "reserved"
+                    ]
+                  },
+                  "last_event_type_reason": {
+                    "enum": [
+                      "user_pick_up"
+                    ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "last_event_type": {
+                    "enum": [
+                      "unavailable"
+                    ]
+                  },
+                  "last_event_type_reason": {
+                    "enum": [
+                      "low_battery",
+                      "maintenance"
+                    ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "last_event_type": {
+                    "enum": [
+                      "removed"
+                    ]
+                  },
+                  "last_event_type_reason": {
+                    "enum": [
+                      "service_end",
+                      "rebalance_pick_up",
+                      "maintenance_pick_up",
+                      "agency_pick_up"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "$id": "#properties/links",
+      "$ref": "#/definitions/links"
+    },
+    "last_updated": {
+      "$id": "#/properties/last_updated",
+      "description": "Timestamp indicating the last time the data in this feed was updated",
+      "$ref": "#/definitions/timestamp"
+    },
+    "ttl": {
+      "$id": "#/properties/ttl",
+      "type": "integer",
+      "title": "Integer representing the number of milliseconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
+      "minimum": 0,
+      "maximum": 300000
+    }
+  },
+  "additionalProperties": false
+}

--- a/schema/README.md
+++ b/schema/README.md
@@ -5,7 +5,9 @@ This directory contains the templates and code that _generate_ the official JSON
 ## Updating the Schemas
 
 1. Edit the appropriate file(s) inside the the `templates` directory.
+
 1. At a command prompt within this `schema` directory run:
+
     ```bash
     python generate_schemas.py
     ```

--- a/schema/generate_schemas.py
+++ b/schema/generate_schemas.py
@@ -144,118 +144,126 @@ if __name__ == '__main__':
         features = { "items": { "$ref": get_definition(MDS_FEATURE_POINT) }, "minItems": 2 }
     )
 
+    # Provider Schemas #
 
-    #########
-    # TRIPS #
-    #########
+    ## /trips Schema ##
 
     # Create the standalone trips JSON schema by including the needed definitions
     trips = get_json_file('./templates/provider/trips.json')
     trips["definitions"] = {
-            POINT: point,
-            MDS_FEATURE_POINT: mds_feature_point,
-            MDS_FEATURECOLLECTION_ROUTE: mds_feature_collection_route,
-            "links": common["definitions"]["links"],
-            "propulsion_type": common["definitions"]["propulsion_type"],
-            "timestamp": common["definitions"]["timestamp"],
-            "vehicle_type": common["definitions"]["vehicle_type"],
-            "version": common["definitions"]["version"],
-            "uuid": common["definitions"]["uuid"],
-            }
-
+        POINT: point,
+        MDS_FEATURE_POINT: mds_feature_point,
+        MDS_FEATURECOLLECTION_ROUTE: mds_feature_collection_route,
+        "links": common["definitions"]["links"],
+        "propulsion_type": common["definitions"]["propulsion_type"],
+        "timestamp": common["definitions"]["timestamp"],
+        "vehicle_type": common["definitions"]["vehicle_type"],
+        "version": common["definitions"]["version"],
+        "uuid": common["definitions"]["uuid"],
+    }
     # Check that it is a valid schema
     jsonschema.Draft6Validator.check_schema(trips)
     # Write to the `provider` directory.
     with open("../provider/dockless/trips.json", "w") as tripfile:
         tripfile.write(json.dumps(trips, indent=2))
 
-
-    ##################
-    # STATUS CHANGES #
-    ##################
+    ## /status_changes Schema ##
 
     # Create the standalone status_changes JSON schema by including the needed definitions
     status_changes = get_json_file('./templates/provider/status_changes.json')
     status_changes["definitions"] = {
-            POINT: point,
-            MDS_FEATURE_POINT: mds_feature_point,
-            "links": common["definitions"]["links"],
-            "propulsion_type": common["definitions"]["propulsion_type"],
-            "timestamp": common["definitions"]["timestamp"],
-            "vehicle_type": common["definitions"]["vehicle_type"],
-            "version": common["definitions"]["version"],
-            "uuid": common["definitions"]["uuid"],
-            }
-
+        POINT: point,
+        MDS_FEATURE_POINT: mds_feature_point,
+        "links": common["definitions"]["links"],
+        "propulsion_type": common["definitions"]["propulsion_type"],
+        "timestamp": common["definitions"]["timestamp"],
+        "vehicle_type": common["definitions"]["vehicle_type"],
+        "version": common["definitions"]["version"],
+        "uuid": common["definitions"]["uuid"],
+    }
     # Check that it is a valid schema
     jsonschema.Draft6Validator.check_schema(status_changes)
     # Write to the `provider` directory.
     with open("../provider/dockless/status_changes.json", "w") as statusfile:
         statusfile.write(json.dumps(status_changes, indent=2))
 
-    ###############
-    # GET VEHICLE #
-    ###############
+    ## /vehicles Schema ##
+
+    # Create the standalone vehicles JSON schema by including the needed definitions
+    vehicles = get_json_file('./templates/provider/vehicles.json')
+    vehicles["definitions"] = {
+        POINT: point,
+        MDS_FEATURE_POINT: mds_feature_point,
+        "links": common["definitions"]["links"],
+        "propulsion_type": common["definitions"]["propulsion_type"],
+        "timestamp": common["definitions"]["timestamp"],
+        "vehicle_type": common["definitions"]["vehicle_type"],
+        "version": common["definitions"]["version"],
+        "uuid": common["definitions"]["uuid"],
+    }
+    # Check that it is a valid schema
+    jsonschema.Draft6Validator.check_schema(vehicles)
+    # Write to the `provider` directory.
+    with open("../provider/dockless/vehicles.json", "w") as statusfile:
+        statusfile.write(json.dumps(vehicles, indent=2))
+
+    # Agency Schemas #
+
+    ## GET VEHICLE ##
 
     # Create the standalone GET vehicle JSON schema by including the needed definitions
     get_vehicle = get_json_file('./templates/agency/get_vehicle.json')
     get_vehicle["definitions"] = {
-            "propulsion_type": common["definitions"]["propulsion_type"],
-            "vehicle_type": common["definitions"]["vehicle_type"],
-            "vehicle_status": common["definitions"]["vehicle_status"],
-            "vehicle_event": common["definitions"]["vehicle_event"],
-            "timestamp": common["definitions"]["timestamp"],
-            "uuid": common["definitions"]["uuid"],
-            }
+        "propulsion_type": common["definitions"]["propulsion_type"],
+        "vehicle_type": common["definitions"]["vehicle_type"],
+        "vehicle_status": common["definitions"]["vehicle_status"],
+        "vehicle_event": common["definitions"]["vehicle_event"],
+        "timestamp": common["definitions"]["timestamp"],
+        "uuid": common["definitions"]["uuid"],
+    }
     # Check that it is a valid schema
     jsonschema.Draft6Validator.check_schema(get_vehicle)
     # Write to the `agency` directory.
     with open("../agency/get_vehicle.json", "w") as file:
         file.write(json.dumps(get_vehicle, indent=2))
 
-    ################
-    # POST VEHICLE #
-    ################
+    ## POST VEHICLE ##
 
     # Create the standalone POST vehicle JSON schema by including the needed definitions
     post_vehicle = get_json_file('./templates/agency/post_vehicle.json')
     post_vehicle["definitions"] = {
-            "propulsion_type": common["definitions"]["propulsion_type"],
-            "vehicle_type": common["definitions"]["vehicle_type"],
-            "uuid": common["definitions"]["uuid"],
-            }
+        "propulsion_type": common["definitions"]["propulsion_type"],
+        "vehicle_type": common["definitions"]["vehicle_type"],
+        "uuid": common["definitions"]["uuid"],
+    }
     # Check that it is a valid schema
     jsonschema.Draft6Validator.check_schema(post_vehicle)
     # Write to the `agency` directory.
     with open("../agency/post_vehicle.json", "w") as file:
         file.write(json.dumps(post_vehicle, indent=2))
 
-    ######################
-    # POST VEHICLE EVENT #
-    ######################
+    ## POST VEHICLE EVENT ##
 
     # Create the standalone POST vehicle event JSON schema by including the needed definitions
     post_vehicle_event = get_json_file('./templates/agency/post_vehicle_event.json')
     post_vehicle_event["definitions"] = {
-            "vehicle_event": common["definitions"]["vehicle_event"],
-            "telemetry": common["definitions"]["telemetry"],
-            "uuid": common["definitions"]["uuid"],
-            }
+        "vehicle_event": common["definitions"]["vehicle_event"],
+        "telemetry": common["definitions"]["telemetry"],
+        "uuid": common["definitions"]["uuid"],
+    }
     # Check that it is a valid schema
     jsonschema.Draft6Validator.check_schema(post_vehicle_event)
     # Write to the `agency` directory.
     with open("../agency/post_vehicle_event.json", "w") as file:
         file.write(json.dumps(post_vehicle_event, indent=2))
 
-    ##########################
-    # POST VEHICLE TELEMETRY #
-    ##########################
+    ## POST VEHICLE TELEMETRY ##
 
     # Create the standalone POST vehicle telemetry JSON schema by including the needed definitions
     post_vehicle_telemetry = get_json_file('./templates/agency/post_vehicle_telemetry.json')
     post_vehicle_telemetry["definitions"] = {
-            "telemetry": common["definitions"]["telemetry"],
-            }
+        "telemetry": common["definitions"]["telemetry"],
+    }
     # Check that it is a valid schema
     jsonschema.Draft6Validator.check_schema(post_vehicle_telemetry)
     # Write to the `agency` directory.

--- a/schema/templates/provider/vehicles.json
+++ b/schema/templates/provider/vehicles.json
@@ -1,0 +1,190 @@
+{
+  "$id": "https://raw.githubusercontent.com/openmobilityfoundation/mobility-data-specification/master/provider/dockless/vehicles.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "The MDS Provider Schema, vehicles payload",
+  "type": "object",
+  "definitions": {},
+  "required": [
+    "version",
+    "data",
+    "last_updated",
+    "ttl"
+  ],
+  "properties": {
+    "version": {
+      "$id": "#/properties/version",
+      "$ref": "#/definitions/version"
+    },
+    "data": {
+      "$id": "#/properties/data",
+      "type": "object",
+      "title": "The page of data",
+      "required": [
+        "vehicles"
+      ],
+      "properties": {
+        "vehicles": {
+          "$id": "#/properties/data/properties/vehicles",
+          "type": "array",
+          "title": "The vehicles Schema",
+          "items": {
+            "$id": "#/properties/data/properties/vehicles/items",
+            "type": "object",
+            "title": "The vehicles items Schema",
+            "required": [
+              "provider_name",
+              "provider_id",
+              "device_id",
+              "vehicle_id",
+              "vehicle_type",
+              "propulsion_type",
+              "last_event_time",
+              "last_event_type",
+              "last_event_type_reason",
+              "last_event_location"
+            ],
+            "properties": {
+              "provider_name": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/provider_name",
+                "type": "string",
+                "description": "The public-facing name of the Provider",
+                "examples": ["Provider Name"],
+                "pattern": "^(.*)$"
+              },
+              "provider_id": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/provider_id",
+                "description": "The UUID for the Provider, unique within MDS",
+                "$ref": "#/definitions/uuid"
+              },
+              "device_id": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/device_id",
+                "description": "A unique device ID in UUID format",
+                "$ref": "#/definitions/uuid"
+              },
+              "vehicle_id": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/vehicle_id",
+                "type": "string",
+                "description": "The Vehicle Identification Number visible on the vehicle itself",
+                "default": "",
+                "examples": ["ABC123"],
+                "pattern": "^(.*)$"
+              },
+              "vehicle_type": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/vehicle_type",
+                "$ref": "#/definitions/vehicle_type",
+                "description": "The type of vehicle"
+              },
+              "propulsion_type": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/propulsion_type",
+                "description": "The type of propulsion; allows multiple values",
+                "$ref": "#/definitions/propulsion_type"
+              },
+              "last_event_time": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/last_event_time",
+                "description": "The time the most recent status change event occurred, expressed as a Unix Timestamp",
+                "$ref": "#/definitions/timestamp"
+              },
+              "last_event_type": {
+                "type": "string",
+                "description": "The type of the event"
+              },
+              "last_event_type_reason": {
+                "type": "string",
+                "description": "The reason for the event"
+              },
+              "last_event_location": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/last_event_location",
+                "description": "Location of the vehicle's last status change event",
+                "$ref": "#/definitions/MDS_Feature_Point"
+              },
+              "current_location": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/current_location",
+                "description": "Current location of vehicle if different from last event, and the vehicle is not currently on a trip",
+                "$ref": "#/definitions/MDS_Feature_Point"
+              },
+              "battery_pct": {
+                "$id": "#/properties/data/properties/vehicles/items/properties/battery_pct",
+                "type": ["number", "null"],
+                "description": "Percent charge of device battery, expressed between 0 and 1",
+                "examples": [0.89],
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "oneOf": [
+              {
+                "properties": {
+                  "last_event_type": {
+                    "enum": ["available"]
+                  },
+                  "last_event_type_reason": {
+                    "enum": [
+                      "service_start",
+                      "user_drop_off",
+                      "rebalance_drop_off",
+                      "maintenance_drop_off",
+                      "agency_drop_off"
+                    ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "last_event_type": {
+                    "enum": ["reserved"]
+                  },
+                  "last_event_type_reason": {
+                    "enum": ["user_pick_up"]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "last_event_type": {
+                    "enum": ["unavailable"]
+                  },
+                  "last_event_type_reason": {
+                    "enum": ["low_battery", "maintenance"]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "last_event_type": {
+                    "enum": ["removed"]
+                  },
+                  "last_event_type_reason": {
+                    "enum": [
+                      "service_end",
+                      "rebalance_pick_up",
+                      "maintenance_pick_up",
+                      "agency_pick_up"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "$id": "#properties/links",
+      "$ref": "#/definitions/links"
+    },
+    "last_updated": {
+      "$id": "#/properties/last_updated",
+      "description": "Timestamp indicating the last time the data in this feed was updated",
+      "$ref": "#/definitions/timestamp"
+    },
+    "ttl": {
+      "$id": "#/properties/ttl",
+      "type": "integer",
+      "title": "Integer representing the number of milliseconds before the data in this feed will be updated again (0 if the data should always be refreshed)",
+      "minimum": 0,
+      "maximum": 300000
+    }
+  },
+  "additionalProperties": false
+}

--- a/schema/templates/provider/vehicles.json
+++ b/schema/templates/provider/vehicles.json
@@ -147,21 +147,6 @@
                     "enum": ["low_battery", "maintenance"]
                   }
                 }
-              },
-              {
-                "properties": {
-                  "last_event_type": {
-                    "enum": ["removed"]
-                  },
-                  "last_event_type_reason": {
-                    "enum": [
-                      "service_end",
-                      "rebalance_pick_up",
-                      "maintenance_pick_up",
-                      "agency_pick_up"
-                    ]
-                  }
-                }
               }
             ]
           }


### PR DESCRIPTION
### Explain pull request

There have been several long running issues & conversations about how to provide real time vs. historical data on vehicles in the PROW. @johnpena specifically requested something like this in #310. 

This goes well with the move to static pagination for historical status changes in #357 , and allows consumers to get the full state of the fleet *right now* rather than having to reconstruct it from a stream of status changes. It's likely this would obviate the need to include GBFS as part of MDS.

This makes MDS more accessible by allowing for a simpler fleet counting method (count the number of vehicles returned in this response). These counts should line up with counts generated from status changes, which would give agencies the ability to fact check real time responses to feel confident they fully reflect what's on the PROW. 

### Is this a breaking change

A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 


 * No, not breaking (This adds a new endpoint that consumers could choose to.. consume)
 

### `Provider` or `agency`

Which API(s) will this pull request impact:

 * `provider`


### Additional context

@johnpena @hunterowens @thekaveman @ascherkus @babldev @hyperknot @rf- @fscottfoti Would love thoughts.

Closes #310.