### PR TITLE
add associated_ticket. Fixes #269

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -300,7 +300,7 @@ Schema: [`status_changes` schema][sc-schema]
 | `event_location` | GeoJSON [Point Feature][geo] | Required | |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `associated_trip` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_type_reason` is `user_pick_up` or `user_drop_off`, or for any other status change event that marks the end of a trip. |
-| `associated_ticket` | String | Optional | An associated ticket inside a 311 or CRM system that a City can tie an event to. | 
+| `associated_ticket` | String | Optional | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system. | 
 
 ### Event Times
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -300,6 +300,7 @@ Schema: [`status_changes` schema][sc-schema]
 | `event_location` | GeoJSON [Point Feature][geo] | Required | |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `associated_trip` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_type_reason` is `user_pick_up` or `user_drop_off`, or for any other status change event that marks the end of a trip. |
+| `associated_ticket` | String | Optional | An associated ticket inside a 311 or CRM system that a City can tie an event to. | 
 
 ### Event Times
 

--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -311,6 +311,10 @@
                 "$id": "#/properties/data/properties/status_changes/items/properties/associated_trip",
                 "description": "Trip UUID, required if event_type_reason is user_pick_up or user_drop_off",
                 "$ref": "#/definitions/uuid"
+              },
+              "associated_ticket": {
+                "type": "string",
+                "description": "An associated ticket inside a 311 or CRM system that a City can tie an event to."
               }
             },
             "allOf": [

--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -314,7 +314,7 @@
               },
               "associated_ticket": {
                 "type": "string",
-                "description": "An associated ticket inside a 311 or CRM system that a City can tie an event to."
+                "description": "Identifier for an associated ticket inside an Agency-maintained 311 or CRM system."
               }
             },
             "allOf": [

--- a/schema/templates/provider/status_changes.json
+++ b/schema/templates/provider/status_changes.json
@@ -115,7 +115,7 @@
               },
               "associated_ticket": {
                 "type": "string",
-                "description": "An associated ticket inside a 311 or CRM system that a City can tie an event to."
+                "description": "Identifier for an associated ticket inside an Agency-maintained 311 or CRM system."
               }
             },
             "allOf": [

--- a/schema/templates/provider/status_changes.json
+++ b/schema/templates/provider/status_changes.json
@@ -112,6 +112,10 @@
                 "$id": "#/properties/data/properties/status_changes/items/properties/associated_trip",
                 "description": "Trip UUID, required if event_type_reason is user_pick_up or user_drop_off",
                 "$ref": "#/definitions/uuid"
+              },
+              "associated_ticket": {
+                "type": "string",
+                "description": "An associated ticket inside a 311 or CRM system that a City can tie an event to."
               }
             },
             "allOf": [


### PR DESCRIPTION
### Explain pull request

In #269, it is brought up that having a 311 or CRM case id to associate with particular status changes may be useful. This PR allows a status change to have a CRM case ID / associated ticket with it. 
### Is this a breaking change

 * No, not breaking - optional field. 
 
### `Provider` or `agency`

 * `provider`

### Additional context

Add any other context or screenshots about the feature request here.
