### PR TITLE
Update JSON schemas for 0.4.0

### DIFF
--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -180,9 +180,9 @@
       "type": "string",
       "title": "The MDS Provider version this data represents",
       "examples": [
-        "0.3.0"
+        "0.4.0"
       ],
-      "pattern": "^0\\.3\\.[0-9]+$"
+      "pattern": "^0\\.4\\.[0-9]+$"
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/provider/dockless/trips.json
+++ b/provider/dockless/trips.json
@@ -211,9 +211,9 @@
       "type": "string",
       "title": "The MDS Provider version this data represents",
       "examples": [
-        "0.3.0"
+        "0.4.0"
       ],
-      "pattern": "^0\\.3\\.[0-9]+$"
+      "pattern": "^0\\.4\\.[0-9]+$"
     },
     "uuid": {
       "$id": "#/definitions/uuid",

--- a/schema/templates/common.json
+++ b/schema/templates/common.json
@@ -9,9 +9,9 @@
       "type": "string",
       "title": "The MDS Provider version this data represents",
       "examples": [
-        "0.3.0"
+        "0.4.0"
       ],
-      "pattern": "^0\\.3\\.[0-9]+$"
+      "pattern": "^0\\.4\\.[0-9]+$"
     },
     "uuid": {
       "$id": "#/definitions/uuid",


### PR DESCRIPTION
### Explain pull request

Bumping the version number string in the common schema, regenerate dockless schemas.

### Is this a breaking change

Yes, `0.4.0` is a new version with breaking changes.

### `Provider` or `agency`

Which API(s) will this pull request impact:

 * `provider`