### PR TITLE
update CODEOWNERS in prep for OMF move

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,10 @@
 ## Below is the MDS CODEOWNERS file, which dictates who is required for review on any given file. 
 
 ## All MDS approvals 
-* @hunterowens @thekaveman @cityoflosangeles/transportation
+* @hunterowens @thekaveman @jfh01
 
 
-## Agency Specific 
-/agency/* @cityoflosangeles/ellis-associates @hunterowens @thekaveman @cityoflosangeles/transportation
+## City Services Working Group Specific, also JSON Schema 
+/agency/*  @hunterowens @thekaveman @jfh01 @henrij
+/schema/*  @hunterowens @thekaveman @jfh01 @henrij
+


### PR DESCRIPTION
### Explain pull request

This PR is part of #386, changes the CODEOWNERS structure to mirror OMF structure. 

### Is this a breaking change
 * No, not breaking

### `Provider` or `agency`

Which API(s) will this pull request impact:

 * both

### Additional context

Add any other context or screenshots about the feature request here.
