### PR TITLE
Add a section clarifying currency units; specify behavior when no currency is given

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -258,7 +258,7 @@ Schema: [`trips` schema][trips-schema]
 | `parking_verification_url` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking |
 | `standard_cost` | Integer | Optional | The cost, in the currency defined in `currency`, that it would cost to perform that trip in the standard operation of the System (see [Costs & Currencies](#costs--currencies)) |
 | `actual_cost` | Integer | Optional | The actual cost, in the currency defined in `currency`, paid by the customer of the *mobility as a service* provider (see [Costs & Currencies](#costs--currencies)) |
-| `currency` | String | Optonal, required if actual or standard cost is not null | An [ISO 4217 Alphabetic Currency Code](https://en.wikipedia.org/wiki/ISO_4217#Active_codes) representing the currency of the payee (see [Costs & Currencies](#costs--currencies)) |
+| `currency` | String | Optional, USD cents is implied if null.| An [ISO 4217 Alphabetic Currency Code](https://en.wikipedia.org/wiki/ISO_4217#Active_codes) representing the currency of the payee (see [Costs & Currencies](#costs--currencies)) |
 
 ### Trips Query Parameters
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -217,6 +217,14 @@ A device may have one or more values from the `propulsion_type`, depending on th
 
 [Top][toc]
 
+### Costs & currencies
+
+Fields specifying a monetary cost use a currency as specified in [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217#Active_codes). All costs should be given as integers in the currency's smallest unit. As an example, to represent $1 USD, specify an amount of `100` (100 cents).
+
+If the currency field is null, USD cents is implied.
+
+[Top][toc]
+
 ## Trips
 
 A trip represents a journey taken by a *mobility as a service* customer with a geo-tagged start and stop point.
@@ -248,9 +256,9 @@ Schema: [`trips` schema][trips-schema]
 | `end_time` | [timestamp][ts] | Required | |
 | `publication_time` | [timestamp][ts] | Optional | Date/time that trip became available through the trips endpoint |
 | `parking_verification_url` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking |
-| `standard_cost` | Integer | Optional | The cost, in the currency defined in `currency`, that it would cost to perform that trip in the standard operation of the System |
-| `actual_cost` | Integer | Optional | The actual cost, in the currency defined in `currency`, paid by the customer of the *mobility as a service* provider |
-| `currency` | String | Optonal, required if actual or standard cost is not null | An [ISO 4217 Alphabetic Currency Code](https://en.wikipedia.org/wiki/ISO_4217#Active_codes) representing the currency of the payee |
+| `standard_cost` | Integer | Optional | The cost, in the currency defined in `currency`, that it would cost to perform that trip in the standard operation of the System (see [Costs & Currencies](#costs--currencies)) |
+| `actual_cost` | Integer | Optional | The actual cost, in the currency defined in `currency`, paid by the customer of the *mobility as a service* provider (see [Costs & Currencies](#costs--currencies)) |
+| `currency` | String | Optonal, required if actual or standard cost is not null | An [ISO 4217 Alphabetic Currency Code](https://en.wikipedia.org/wiki/ISO_4217#Active_codes) representing the currency of the payee (see [Costs & Currencies](#costs--currencies)) |
 
 ### Trips Query Parameters
 

--- a/provider/dockless/trips.json
+++ b/provider/dockless/trips.json
@@ -376,7 +376,7 @@
                   "integer",
                   "null"
                 ],
-                "description": "The cost, in the currency defined in `currency`, that it would cost to perform that trip in the standard operation of the System",
+                "description": "The cost, in the currency defined in `currency`, that it would cost to perform that trip in the standard operation of the System. If no currency is given, USD cents is implied.",
                 "examples": [
                   500
                 ]
@@ -387,7 +387,7 @@
                   "integer",
                   "null"
                 ],
-                "description": "The actual cost, in the currency defined in `currency`, paid by the customer of the *mobility as a service* providerim",
+                "description": "The actual cost, in the currency defined in `currency`, paid by the customer of the *mobility as a service* provider. If no currency is given, USD cents is implied.",
                 "examples": [
                   520
                 ]

--- a/provider/dockless/trips.json
+++ b/provider/dockless/trips.json
@@ -398,7 +398,7 @@
                   "string",
                   "null"
                 ],
-                "description": "An ISO 4217 AlphabeticCurrency Code representing the currency of the payee.",
+                "description": "An ISO 4217 Alphabetic Currency Code representing the currency of the payee. If null, USD cents is implied.",
                 "examples": [
                   "USD",
                   "EUR",

--- a/schema/templates/provider/trips.json
+++ b/schema/templates/provider/trips.json
@@ -163,9 +163,8 @@
               },
               "currency": {
                 "$id": "#/properties/data/properties/trips/items/properties/currency",
-                "type": ["string"
-                          , "null"],
-                "description": "An ISO 4217 AlphabeticCurrency Code representing the currency of the payee.",
+                "type": ["string", "null"],
+                "description": "An ISO 4217 Alphabetic Currency Code representing the currency of the payee. If null, USD cents is implied.",
                 "examples": [
                     "USD", "EUR", "GBP"
                 ]

--- a/schema/templates/provider/trips.json
+++ b/schema/templates/provider/trips.json
@@ -148,7 +148,7 @@
               "standard_cost": {
                 "$id": "#/properties/data/properties/trips/items/properties/standard_cost",
                 "type": ["integer", "null"],
-                "description": "The cost, in the currency defined in `currency`, that it would cost to perform that trip in the standard operation of the System",
+                "description": "The cost, in the currency defined in `currency`, that it would cost to perform that trip in the standard operation of the System. If no currency is given, USD cents is implied.",
                 "examples": [
                   500
                 ]
@@ -156,7 +156,7 @@
               "actual_cost": {
                 "$id": "#/properties/data/properties/trips/items/properties/actual_cost",
                 "type": ["integer", "null"],
-                "description": "The actual cost, in the currency defined in `currency`, paid by the customer of the *mobility as a service* providerim",
+                "description": "The actual cost, in the currency defined in `currency`, paid by the customer of the *mobility as a service* provider. If no currency is given, USD cents is implied.",
                 "examples": [
                   520
                 ]


### PR DESCRIPTION
### Explain pull request

This PR fixes a couple of bugs introduced in #379.

Firstly, the schema only allows integral costs; this is insufficient for many currencies that contain a fractional part (including USD). This PR changes the types of the cost fields to `number` instead of `integer`. Since `number` is a superset of `integer`, this should not break backwards compatibility.

Additionally, the wording does not specify the behavior when the `currency` field is not present. This change clarifies the language to use the old definition (cents of USD) to keep backwards compatibility.

### Is this a breaking change

 * No, not breaking

### `Provider` or `agency`

 * `provider`
