### PR TITLE
Provider language cleanup

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -15,7 +15,8 @@ This specification contains a data standard for *mobility as a service* provider
 
 The following information applies to all `provider` API endpoints. Details on providing authorization to endpoints is specified in the [auth](auth.md) document.
 
-Currently, the provider API is implemented for dockless scooter and bikeshare. To implement another mode, add it to the `schema/generate_schema.py` file and this README and submit a pull request. 
+Currently, the provider API is implemented for dockless scooter and bikeshare. To implement another mode, add it to the `schema/generate_schema.py` file and this README and submit a pull request.
+
 ### Versioning
 
 `provider` APIs must handle requests for specific versions of the specification from clients.
@@ -171,6 +172,7 @@ represented as a GeoJSON [`Feature`](https://tools.ietf.org/html/rfc7946#section
 ```
 
 #### Intersection Operation
+
 For the purposes of this specification, the intersection of two geographic datatypes is defined according to the [`ST_Intersects` PostGIS operation](https://postgis.net/docs/ST_Intersects.html)
 
 > If a geometry or geography shares any portion of space then they intersect. For geography -- tolerance is 0.00001 meters (so any points that are close are considered to intersect).<br>
@@ -256,7 +258,7 @@ The `/trips` API should allow querying trips with the following query parameters
 
 | Parameter | Format | Expected Output |
 | --------------- | ------ | --------------- |
-| `end_time` | `YYYY-MM-DDTHH`, an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended datetime representing an UTC hour between 00 and 23. | All trips with an end time occurring within the hour. For example, requesting `end_time=2019-10-01T07` returns all trips where `07:00 <= trip.end_time < 08:00` on October 01, 2019 UTC. |
+| `end_time` | `YYYY-MM-DDTHH`, an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended datetime representing an UTC hour between 00 and 23. | All trips with an end time occurring within the hour. For example, requesting `end_time=2019-10-01T07` returns all trips where `2019-10-01T07:00:00 <= trip.end_time < 2019-10-01T08:00:00` UTC. |
 
 If the data does not exist or the hour has not completed, `/trips` shall return a `404 Not Found` error.
 
@@ -346,7 +348,7 @@ The `/status_changes` API should allow querying status changes with the followin
 
 | Parameter | Format | Expected Output |
 | --------------- | ------ | --------------- |
-| `event_time` | `YYYY-MM-DDTHH`, an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended datetime representing an UTC hour between 00 and 23. | All status changes with an event time occurring within the hour. For example, requesting `event_time=2019-10-01T07` returns all status changes where `07:00 <= status_change.event_time < 08:00` on October 01, 2019 UTC. |
+| `event_time` | `YYYY-MM-DDTHH`, an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended datetime representing an UTC hour between 00 and 23. | All status changes with an event time occurring within the hour. For example, requesting `event_time=2019-10-01T07` returns all status changes where `2019-10-01T07:00:00 <= status_change.event_time < 2019-10-01T08:00:00` UTC. |
 
 If the data does not exist or the hour has not completed, `/status_changes` shall return a `404 Not Found` error.
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -414,9 +414,9 @@ The events API should allow querying with a combination of query parameters:
 | `start_time` | [timestamp][ts] | status changes where `start_time <= status_change.event_time` |
 | `end_time` | [timestamp][ts] | status changes where `status_change.event_time < end_time` |
 
-Should either side of the requested time range be missing, the API shall return a `400 Bad Request` error.
+Should either side of the requested time range be missing, `/events` shall return a `400 Bad Request` error.
 
-Should either side of the requested time range be greater than 2 weeks before the time of the request, the API shall return a `400 Bad Request` error.
+Should either side of the requested time range be greater than 2 weeks before the time of the request, `/events` shall return a `400 Bad Request` error.
 
 [Top][toc]
 


### PR DESCRIPTION
### Explain pull request

Additional clarity for the recent static file changes #357.

### Is this a breaking change

 * No, not breaking

### `Provider` or `agency`

 * `provider`