### PR TITLE
Small typo in policy spec

### DIFF
--- a/policy/examples.md
+++ b/policy/examples.md
@@ -144,10 +144,10 @@ This Policy allows scooters and bikes can be in the public right-of-way for up t
       "geographies": [
         "12b3fcf5-22af-4b0d-a169-ac7ac903d3b9"
       ],
-      "statuses": [
-        "unavailable",
-        "trip"
-      ],
+      "statuses": {
+        "unavailable": [],
+        "trip": []
+      },
       "vehicle_types": [
         "bicycle",
         "scooter"


### PR DESCRIPTION
### Explain pull request

This is simply to fix a typo in the example provided for the policy.

### Is this a breaking change

 * No, not breaking

### `Provider` or `agency`

It will have no impact on the APIs
