### PR TITLE
Add `decommissioned` event type reason to agency vehicle_event schema

### DIFF
--- a/agency/post_vehicle_event.json
+++ b/agency/post_vehicle_event.json
@@ -142,7 +142,8 @@
             },
             "event_type_reason": {
               "enum": [
-                "missing"
+                "missing",
+                "decommissioned"
               ]
             }
           }


### PR DESCRIPTION
### Explain pull request

The vehicle_event schema file does not include the `decommissioned` event_type reason added in 0.3.1. This PR ensures the schema matches the spec.

### Is this a breaking change

 * No, not breaking

### Impacted Spec

Which spec(s) will this pull request impact?

 * `agency`
