### PR TITLE
Policy Rule Necessity options

### DIFF
--- a/policy/README.md
+++ b/policy/README.md
@@ -237,6 +237,7 @@ An individual `Rule` object is defined by the following fields:
 | `geographies`      | UUID[]                      | Required   | List of [Geography](/geography#general-information) UUIDs (non-overlapping) specifying the covered geography |
 | `states`           | `{ state: event[] }`        | Required   | [Vehicle state][vehicle-states] to which this rule applies. Optionally provide a list of specific [vehicle events][#vehicle-events] as a subset of a given status for the rule to apply to. An empty list or `null`/absent defaults to "all". |
 | `rule_units`       | enum                        | Conditionally Required   | Measured units of policy (see [Rule Units](#rule-units)) |
+| `necessity`        | enum                        | Optional   | Necessity of adhering to this rule. Values in order of necessity: `required`, `recommended`, `optional`. The default value is `required`. |
 | `vehicle_types`    | `vehicle_type[]`            | Optional   | Applicable vehicle types, default "all". |
 | `propulsion_types` | `propulsion_type[]`         | Optional   | Applicable vehicle [propulsion types][propulsion-types], default "all". |
 | `minimum`          | integer                     | Optional   | Minimum value, if applicable (default 0) |


### PR DESCRIPTION
## Explain pull request

Per #557 adding a new rule optional field called `necessity` which enumerates some options for policy makers to attach to a rule:

- required (default)
- recommended
- optional

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which spec(s) will this pull request impact?

* `policy`

## Additional context

I'm not totally happy with the `necessity` field name, but it does seem to make some sense, describing how necessary the rule is.  Other options could be `requirement`, `enforcement`, or `importance`.

Note the 3 enumerated values may require more explanation, or others could be added, like testing.
