### PR TITLE
Align propulsion_types in provider/status_changes spec and .ReadMe

### DIFF
--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -124,25 +124,16 @@
         }
       }
     },
-    "propulsion_type": {
-      "$id": "#/definitions/propulsion_type",
+    "propulsion_types": {
+      "$id": "#/definitions/propulsion_types",
       "type": "string",
-      "description": "The type of propulsion",
+      "description": "Array of propulsion types, allowing multiple values",
       "enum": [
         "combustion",
         "electric",
         "electric_assist",
         "human"
-      ]
-    },
-    "propulsion_types": {
-      "$id": "#/definitions/propulsion_types",
-      "type": "array",
-      "description": "Array of propulsion types, allowing multiple values",
-      "items": {
-        "$id": "#/definitions/propulsion_types/items",
-        "$ref": "#/definitions/propulsion_type"
-      },
+      ],
       "uniqueItems": true
     },
     "vehicle_type": {

--- a/provider/status_changes.json
+++ b/provider/status_changes.json
@@ -126,7 +126,7 @@
     },
     "propulsion_types": {
       "$id": "#/definitions/propulsion_types",
-      "type": "string",
+      "type": "array",
       "description": "Array of propulsion types, allowing multiple values",
       "enum": [
         "combustion",


### PR DESCRIPTION
---
name: Emmett McKinney
about: Suggest changes to MDS
title: Aligning "propulsion_types" in provider/status_changes spec with ReadMe.

---

## Explain pull request

The [ReadMe](https://github.com/openmobilityfoundation/mobility-data-specification/tree/release-1.0.0) for provider/status_changes.json 1.0.0 and the [spec](https://github.com/openmobilityfoundation/mobility-data-specification/blob/release-1.0.0/provider/status_changes.json) appear to conflict on the deprecated 'propulsion_type' field.   We suggest renaming the `propulsion_type` object to `propulsion_types` (i.e., adding an 's'), replacing the `$id` reference with an enum[], and removing the existing `propulsion_types` object.


## Is this a breaking change

* Yes, breaking

## Impacted Spec

* `agency`
* `provider`

## Additional context

The competing fields begin at Line 127 of provider/status_changes.json and Line 138, respectively. This caused some confusion for us while validating our Provider feeds. 