### PR TITLE
1.2.0 schemas: version in policy examples

### DIFF
--- a/policy/examples/idle-time.json
+++ b/policy/examples/idle-time.json
@@ -1,6 +1,6 @@
 {
   "updated": 0,
-  "version": "1.0.0",
+  "version": "1.2.0",
   "data": {
     "policies": [
       {

--- a/policy/examples/metered-parking-fees.json
+++ b/policy/examples/metered-parking-fees.json
@@ -1,6 +1,6 @@
 {
   "updated": 0,
-  "version": "1.0.0",
+  "version": "1.2.0",
   "data": {
     "policies": [
       {

--- a/policy/examples/per-trip-fees.json
+++ b/policy/examples/per-trip-fees.json
@@ -1,6 +1,6 @@
 {
   "updated": 0,
-  "version": "1.0.0",
+  "version": "1.2.0",
   "data": {
     "policies": [
       {

--- a/policy/examples/prohibited-zone.json
+++ b/policy/examples/prohibited-zone.json
@@ -1,6 +1,6 @@
 {
   "updated": 0,
-  "version": "1.0.0",
+  "version": "1.2.0",
   "data": {
     "policies": [
       {

--- a/policy/examples/provider-cap.json
+++ b/policy/examples/provider-cap.json
@@ -1,6 +1,6 @@
 {
   "updated": 0,
-  "version": "1.0.0",
+  "version": "1.2.0",
   "data": {
     "policies": [
       {

--- a/policy/examples/required-parking.json
+++ b/policy/examples/required-parking.json
@@ -1,6 +1,6 @@
 {
   "updated": 0,
-  "version": "1.0.0",
+  "version": "1.2.0",
   "data": {
     "policies": [
       {

--- a/policy/examples/requirements.md
+++ b/policy/examples/requirements.md
@@ -134,7 +134,7 @@ Version 1.1.0 for one provider with scooters, and 1.0.0 for another provider for
       "required_data_specs": [
         {
           "data_spec_name": "MDS",
-          "version": "1.1.0",
+          "version": "1.2.0",
           "required_apis": [
             {
               "api_name": "provider",
@@ -167,7 +167,7 @@ Version 1.1.0 for one provider with scooters, and 1.0.0 for another provider for
       "required_data_specs": [
         {
           "data_spec_name": "MDS",
-          "version": "1.0.0",
+          "version": "1.2.0",
           "required_apis": [
             {
               "api_name": "provider",
@@ -224,7 +224,7 @@ Version 1.1.0 for 2 providers requiring only historic Provider `/trips` with the
       "required_data_specs": [
         {
           "data_spec_name": "MDS",
-          "version": "1.1.0",
+          "version": "1.2.0",
           "required_apis": [
             {
               "api_name": "provider",
@@ -284,7 +284,7 @@ Version 1.1.0 for 2 providers asking for only historic [Provider `/trips`](/prov
       "required_data_specs": [
         {
           "data_spec_name": "MDS",
-          "version": "1.1.0",
+          "version": "1.2.0",
           "required_apis": [
             {
               "api_name": "provider",
@@ -352,7 +352,7 @@ Note: by specifying geography, policy, and jurisdiction here with a URL, the age
       "required_data_specs": [
         {
           "data_spec_name": "MDS",
-          "version": "1.1.0",
+          "version": "1.2.0",
           "required_apis": [
             {
               "api_name": "provider",
@@ -535,7 +535,7 @@ Version 1.1.0 for 3 providers and serving Agency only linking to a defined MDS P
       "required_data_specs": [
         {
           "data_spec_name": "MDS",
-          "version": "1.1.0",
+          "version": "1.2.0",
           "required_apis": [
             {
               "api_name": "agency",
@@ -620,7 +620,7 @@ Version 1.1.0 for 2 providers requiring Provider `/status_changes` with the mini
       "required_data_specs": [
         {
           "data_spec_name": "MDS",
-          "version": "1.1.0",
+          "version": "1.2.0",
           "required_apis": [
             {
               "api_name": "provider",

--- a/policy/examples/speed-limits.json
+++ b/policy/examples/speed-limits.json
@@ -1,6 +1,6 @@
 {
   "updated": 0,
-  "version": "1.0.0",
+  "version": "1.2.0",
   "data": {
     "policies": [
       {

--- a/policy/examples/vehicle-row-fees.json
+++ b/policy/examples/vehicle-row-fees.json
@@ -1,6 +1,6 @@
 {
   "updated": 0,
-  "version": "1.0.0",
+  "version": "1.2.0",
   "data": {
     "policies": [
       {


### PR DESCRIPTION
## Explain pull request

Similar to #716, not technically the schemas, but updating version in the examples (so they pass schema validation!)

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which spec(s) will this pull request impact?

* `policy`
