### PR TITLE
Return only relevant geographies in Provider Reports

### DIFF
--- a/policy/README.md
+++ b/policy/README.md
@@ -737,6 +737,7 @@ You may also show which APIs, endpoints, and fields your agency is serving to pr
 | `required_endpoints` | Array | Required | Array of optional endpoints required by the agency. At least one is required. Endpoints not listed will not be available to the agency. |
 | `required_fields`    | Array | Optional | Array of optional field names required by the agency. Can be omitted if no optional fields are required. Use dot notation for nested fields. See **special notes** below. |
 | `disallowed_fields`  | Array | Optional | Array of optional field names which must not be returned by in the endpoint, even if required in MDS. Use dot notation for nested fields. See **special notes** below. |
+| `report_geographies`        | Array | Optional | Array of geography UUIDs (sourced from the Agency's Geographies API) that are the only geographies to be returned in Provider [Reports](../provider#reports). |
 
 **Agency Endpoints** - Specific to the `available_apis` array
 


### PR DESCRIPTION
## Explain pull request

In response to Issue #873, adding an optional `geographies` field to endpoints in Policy Requirements to allow for a list of relevant geographies to that endpoint.   Issue #873 refers to adding relevant geographies to the reports endpoint only.  I drafted this PR so that it could apply to any endpoint, but not sure that's necessary.  If we want it to be more flexible, we may want to add it to Agency endpoints as well.  I haven't thought through potential use cases for this, though.

## Is this a breaking change

* No, not breaking

## Impacted Spec

* `policy`

## Additional context

Add any other context or screenshots about the feature request here.
