### PR TITLE
Add service_start and service_end to Vehicle object in Provider and Agency APIs

### DIFF
--- a/data-types.md
+++ b/data-types.md
@@ -34,6 +34,9 @@ A vehicle record is as follows:
 | `battery_capacity`   | Integer  | Required if Available | Capacity of battery expressed as milliamp hours (mAh) |
 | `fuel_capacity`      | Integer  | Required if Available | Capacity of fuel tank (liquid, solid, gaseous) expressed in liters |
 | `maximum_speed`      | Integer  | Required if Available | Maximum speed (kph) possible with vehicle under normal, flat incline, smooth surface conditions. Applicable if the device has a built-in or intelligent speed limiter/governor. |
+|`service_start`       |Timestamp | Required              | Date/time the vehicle starts providing service |
+|`service_end`         |Timestamp | Required if Available | Date/time the vehicle stops providing service. Required if the vehicle is retired |
+
 
 [Top][toc]
 

--- a/data-types.md
+++ b/data-types.md
@@ -34,7 +34,7 @@ A vehicle record is as follows:
 | `battery_capacity`   | Integer  | Required if Available | Capacity of battery expressed as milliamp hours (mAh) |
 | `fuel_capacity`      | Integer  | Required if Available | Capacity of fuel tank (liquid, solid, gaseous) expressed in liters |
 | `maximum_speed`      | Integer  | Required if Available | Maximum speed (kph) possible with vehicle under normal, flat incline, smooth surface conditions. Applicable if the device has a built-in or intelligent speed limiter/governor. |
-|`service_start`       |Timestamp | Required              | Date/time the vehicle starts providing service |
+|`service_start`       |Timestamp | Conditionally Required   | Date/time the vehicle starts providing service. Required if asked for by public agency. |
 |`service_end`         |Timestamp | Required if Available | Date/time the vehicle stops providing service. Required if the vehicle is retired |
 
 

--- a/data-types.md
+++ b/data-types.md
@@ -34,9 +34,8 @@ A vehicle record is as follows:
 | `battery_capacity`   | Integer  | Required if Available | Capacity of battery expressed as milliamp hours (mAh) |
 | `fuel_capacity`      | Integer  | Required if Available | Capacity of fuel tank (liquid, solid, gaseous) expressed in liters |
 | `maximum_speed`      | Integer  | Required if Available | Maximum speed (kph) possible with vehicle under normal, flat incline, smooth surface conditions. Applicable if the device has a built-in or intelligent speed limiter/governor. |
-|`service_start`       |Timestamp | Conditionally Required   | Date/time the vehicle starts providing service. Required if asked for by public agency. |
-|`service_end`         |Timestamp | Required if Available | Date/time the vehicle stops providing service. Required if the vehicle is retired |
-
+| `commissioned`       | [Timestamp][ts] | Conditionally Required | Date/time the vehicle first starts providing service in the jurisdiction. Required if asked for by public agency. |
+| `decommissioned`     | [Timestamp][ts] | Conditionally Required | Date/time the vehicle stops providing service in the jurisdiction and is decommissioned. Required when the vehicle is retired from operations. |
 
 [Top][toc]
 


### PR DESCRIPTION
## Explain pull request

In response to Issue https://github.com/openmobilityfoundation/mobility-data-specification/issues/899, adding a required field service_start and required if available field service_end to Vehicle endpoint of Provider API.


* No, not breaking

## Impacted Spec

* `provider`

