### PR TITLE
Externally Reference Overlapping Data Sources (WZDz, CWZ, CDS, MDS, GBFS, GTFS, 311, Police Reports, etc)

### DIFF
--- a/data-types.md
+++ b/data-types.md
@@ -16,7 +16,8 @@ This MDS data types page catalogs the objects (fields, types, requirements, desc
   - [Stop Status](#stop-status)
 - [Trips](#trips)
 - [Reports](#reports)
-
+- [External Reference](#external-reference)
+- 
 ## Vehicles
 
 A vehicle record is as follows:
@@ -295,6 +296,22 @@ Here are the possible values for the `special_group_type` dimension field:
 | all_riders       | All riders from any group                                                                                             |
 
 Other special group types may be added in future MDS releases as relevant agency and provider use cases are identified. When additional special group types or metrics are proposed, a thorough review of utility and relevance in program oversight, evaluation, and policy development should be done by OMF Working Groups, as well as any privacy implications by the OMF Privacy Committee.
+
+[Top][toc]
+
+## External Reference
+
+An External Reference object describes a specific feature from a data feed or API that is relevant to the curb place via an external reference. This allows CDS users to reference other data feeds, documents, websites, or URLs that impact or provide information, and see more details in an external URL. Data feeds can be any existing standard (MDS, WZDx, CWZ, GTFS, GBFS, CDS, etc), custom feed, document, web page, etc.
+
+An `external_reference` is a JSON *array* with the following fields within objects:
+
+| Name   | Type   | Required/Optional   | Description   |
+| ------ | ------ | ------------------- | ------------- |
+| `data_feed_url` | URL | Required | A web-accessible identifier for the source of the publicly or privately accessible data feed, document, website, or URL. This MUST be a full HTTPS URL pointing to a location which contains more information impacting or explaining the location or policy. |
+| `name` | String | Optional | Name of the data feed for reference. E.g. "WZDx", "CWZ", "MDS", "GBFS", "GTFS", "CDS". |
+| `public` | Boolean | Optional | Is this data feed able to be viewed with out any sort of authentication? If `true`, the `data_feed_url` is public. If `false`, the `data_feed_url` requires some sort of authentication, authorization, or API key to access. This is an informational field to set access expectations for the feed user, and does not provide any credentials directly unless explicitly contained in the `data_feed_url` URL string. |
+| `identifier_name` | String | Optional | The name of the data field or object that is referenced by the unique `ids`. E.g. "id", "report_id", "trip_id", "vehicle_id", "RoadEventFeature", etc, if relevant and available in the URL. |
+| `ids` | Array of Strings | Optional | An array of one or more **ids** from the data feed that impacts the use of or relationship to part of CDS, e.g. a curb zone, curb space, curb area, curb event, etc. The **ids** and their details are be found in the referenced `data_feed_url`. |
 
 [Top][toc]
 


### PR DESCRIPTION
## Explain pull request

Adding a reference to any kind of data feed or external doc, similar to what we have done with CDS.  https://github.com/openmobilityfoundation/curb-data-specification/pull/96

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which spec(s) will this pull request impact?

* `agency`
* `policy`
* `provider`

## Additional context

Adding the external reference object here, to be used as needed across the spec.
