### PR TITLE
Update Policy Authorization description to allow authentication

### DIFF
--- a/policy/README.md
+++ b/policy/README.md
@@ -151,9 +151,9 @@ See the [Responses section][responses] for information on valid MDS response cod
 
 **Endpoint**: `/policies/{policy_id}`  
 **Method**: `GET`  
-**Schema:** See [`mds-openapi`](https://github.com/openmobilityfoundation/mds-openapi) repository for schema.    
-**Authorization**: public _or_ authenticated (see [Authorization](#authorization)) 
-**`data` Payload**: `{ "policies": [] }`, an array of objects with the structure [outlined below](#policy).
+**Schema:** See [`mds-openapi`](https://github.com/openmobilityfoundation/mds-openapi) repository for schema.  
+**Authorization**: public _or_ authenticated (see [Authorization](#authorization))  
+**`data` Payload**: `{ "policies": [] }`, an array of objects with the structure [outlined below](#policy).  
 
 _Path Parameters:_
 
@@ -200,8 +200,8 @@ See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schem
 
 **Endpoint**: `/requirements/`  
 **Method**: `GET`  
-**[Beta feature](/general-information.md#beta-features)**: *No (as of 2.0.0)*. 
-**Authorization**: public
+**[Beta feature](/general-information.md#beta-features)**: *No (as of 2.0.0)*.  
+**Authorization**: public  
 **Schema:** See [`mds-openapi`](https://github.com/openmobilityfoundation/mds-openapi) repository for schema.  
 **`data` Payload**: `{ requirements: [] }`, JSON objects that follow the schema [outlined here](#requirement).  
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -152,7 +152,7 @@ See the [Responses section][responses] for information on valid MDS response cod
 **Endpoint**: `/policies/{policy_id}`  
 **Method**: `GET`  
 **Schema:** See [`mds-openapi`](https://github.com/openmobilityfoundation/mds-openapi) repository for schema.    
-**Authorization**: public  
+**Authorization**: public _or_ authenticated (see [Authorization](#authorization)) 
 **`data` Payload**: `{ "policies": [] }`, an array of objects with the structure [outlined below](#policy).
 
 _Path Parameters:_
@@ -201,7 +201,7 @@ See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schem
 **Endpoint**: `/requirements/`  
 **Method**: `GET`  
 **[Beta feature](/general-information.md#beta-features)**: *No (as of 2.0.0)*. 
-**Authorization**: public  
+**Authorization**: public
 **Schema:** See [`mds-openapi`](https://github.com/openmobilityfoundation/mds-openapi) repository for schema.  
 **`data` Payload**: `{ requirements: [] }`, JSON objects that follow the schema [outlined here](#requirement).  
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -82,7 +82,7 @@ See the [MDS Policy Examples](https://github.com/openmobilityfoundation/mobility
 
 In most cases, the Policy endpoints should be made public. Authorization is not required in such cases. Agencies may make reasonable accommodations to manage their endpoints, for example, using an API key that has a clear, public way to obtain - this can be useful for rate limiting requests, ensure proper use, tracking access per requestor, and/or customization of the Policy tailored to the requestor.
 
-In some cases though, it can be justified to use Authorization for the Policy API (some agencies may decide to make it authenticated for privacy programs or functional purposes). Authorization may then be used for the Policy API. It should then rely on the standard Authorization methods used in other MDS APIs. 
+In some cases though, it can be justified to use Authorization for the Policy API (some agencies may decide to make it authenticated for privacy programs or functional purposes). Authorization may then be used for the Policy API. It should then rely on the standard [Authorization](../general-information.md#authorization) methods used in other MDS APIs. 
 
 [Top][toc]
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -80,7 +80,9 @@ See the [MDS Policy Examples](https://github.com/openmobilityfoundation/mobility
 
 ### Authorization
 
-The Policy endpoints should be made public. Authorization is not required. Agencies may make reasonable accommodations to manage their endpoints, for example, using an API key that has a clear, public way to obtain - this can be useful for rate limiting requests, ensure proper use, tracking access per requestor, and/or customization of the Policy tailored to the requestor.
+In most cases, the Policy endpoints should be made public. Authorization is not required in such cases. Agencies may make reasonable accommodations to manage their endpoints, for example, using an API key that has a clear, public way to obtain - this can be useful for rate limiting requests, ensure proper use, tracking access per requestor, and/or customization of the Policy tailored to the requestor.
+
+In some cases though, it can be justified to use Authorization for the Policy API (some agencies may decide to make it authenticated for privacy programs or functional purposes). Authorization may then be used for the Policy API. It should then rely on the standard Authorization methods used in other MDS APIs. 
 
 [Top][toc]
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -80,7 +80,9 @@ See the [MDS Policy Examples](https://github.com/openmobilityfoundation/mobility
 
 ### Authorization
 
-In most cases, the Policy endpoints should be made public. Authorization is not required in such cases. Agencies may make reasonable accommodations to manage their endpoints, for example, using an API key that has a clear, public way to obtain - this can be useful for rate limiting requests, ensure proper use, tracking access per requestor, and/or customization of the Policy tailored to the requestor.
+In most cases, the Policy endpoints should be made public. Authorization is not required in such cases, as this information should be made public and easily accessible. 
+
+Agencies may make reasonable accommodations to manage their endpoints by, for example, using a free to acquire API key that has a clear, public way to obtain. This can be useful for rate limiting requests, prevent abuse, ensure proper use, tracking access per requestor, for certain mobility programs or pilots, and/or customization of the Policy tailored to the requestor.
 
 In some cases though, it can be justified to use Authorization for the Policy API (some agencies may decide to make it authenticated for privacy programs or functional purposes). Authorization may then be used for the Policy API. It should then rely on the standard [Authorization](../general-information.md#authorization) methods used in other MDS APIs. 
 


### PR DESCRIPTION
## Explain pull request

In the Policy API section, this PR updates the Authorization description to allow for authentication when use-cases justify it. 

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which spec(s) will this pull request impact?

* `policy`

## Additional context

Relates to #915 