### PR TITLE
Adding distance rule types and relevant rule units to policy documentation

### DIFF
--- a/policy/README.md
+++ b/policy/README.md
@@ -357,10 +357,11 @@ An individual `Rule` object is defined by the following fields:
 
 ### Rule Types
 
-| Name    | Description                                                                                                   |
+| Name      | Description                                                                                                   |
 | ------- | ------------------------------------------------------------------------------------------------------------- |
 | `count` | Fleet counts based on regions. Rule `minimum`/`maximum` refers to number of devices in [Rule Units](#rule-units).                                  |
 | `time`  | Individual limitations or fees based upon time spent in one or more vehicle states. Rule `minimum`/`maximum` refers to increments of time in [Rule Units](#rule-units). |
+| `distance`  | Individual limitations or fees based upon distance travelled during one or more trips. Rule `minimum`/`maximum` refers to increments of distance in [Rule Units](#rule-units). |
 | `speed` | Global or local speed limits. Rule `minimum`/`maximum` refers to speed in [Rule Units](#rule-units).                  |
 | `user`  | Information for users, e.g. about helmet laws. Generally can't be enforced via events and telemetry.          |
 
@@ -374,6 +375,8 @@ An individual `Rule` object is defined by the following fields:
 | `minutes` | `time`         | Minutes             |
 | `hours`   | `time`         | Hours               |
 | `days`    | `time`         | Days                |
+| `km`      | `distance`     | Kilometers          |
+| `miles`   | `distance`     | Miles               |
 | `mph`     | `speed`        | Miles per hour      |
 | `kph`     | `speed`        | Kilometers per hour |
 | `devices` | `count`        | Devices             |


### PR DESCRIPTION
## Explain pull request

In order to add the possibility for policies to express limitations related to distance travelled, we are adding a 'distance' [rule type](https://github.com/openmobilityfoundation/mobility-data-specification/tree/main/policy#rule-types) to the Policy API documentation. In addition to that, we are also adding the relevant [rule units](https://github.com/openmobilityfoundation/mobility-data-specification/tree/main/policy#rule-units) to policy documentation.

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which spec(s) will this pull request impact?

* `policy`

## Additional context

Relates to issue #908 which will be closed when this is merged. 