### PR TITLE
Creating an option to Push Policies

### DIFF
--- a/geography/README.md
+++ b/geography/README.md
@@ -296,9 +296,9 @@ See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schem
 | -------------------- | -----------------------------------------------| ------------------------------- |
 | `bad_param`          | A validation error occurred                    | Array of parameters with errors |
 | `missing_param`      | A required parameter is missing                | Array of missing parameters     |
-| `already_created`    | A geography with `geography_id` is already created   |                                 |
+| `already_created`    | A geography with `geography_id` is already created   |                           |
 
-Note that you may only create a new MDS Policy. Retired policies are simply referenced in `prev_policies`. See [Updating or Ending Policies](#updating-or-ending-policies) for details.
+Note that you may only create a new MDS Geography. Retired geographies are simply referenced in `prev_geographies`. See [Distribution](#distribution) for details.
 
 [Top][toc]
 

--- a/geography/README.md
+++ b/geography/README.md
@@ -24,6 +24,7 @@ Geographical data will be stored as GeoJSON and read from either `geographies.js
 - [Endpoints](#endpoints)
   - [Geography](#geography)
   - [Geographies](#geographies)
+  - [Geographies - Create](#geographies---create)
 - [Examples](#examples)
 
 ## General Information
@@ -180,6 +181,7 @@ The Geography API consists of the following endpoints:
 **Endpoint**: `/geographies/{geography_id}`  
 **Method**: `GET`  
 **Schema:** See [`mds-openapi`](https://github.com/openmobilityfoundation/mds-openapi) repository for schema.  
+**Authorization**: public  
 
 #### Path Parameters
 
@@ -225,6 +227,7 @@ See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schem
 **Endpoint**: `/geographies`  
 **Method**: `GET`  
 **Schema:** See [`mds-openapi`](https://github.com/openmobilityfoundation/mds-openapi) repository for schema.  
+**Authorization**: public  
 
 Returns: All geography objects
 
@@ -254,6 +257,48 @@ _Possible HTTP Status Codes_:
 500
 
 See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schema] for details.
+
+[Top][toc]
+
+### Geographies - Create
+
+Allows agencies to push a newly created policies to geographies, similar to the Agency API. This push method creates the opportunity for near real-time communication of geography changes.
+
+Note that once an update is communicated via a policy push, the agency should pull from the relevant [Geography API](../geography) endpoint to see if there are new or changed geographic areas. 
+
+Endpoint producers **SHALL** provide authorization for API endpoints via a bearer token based auth system specified in the MDS [Authorization section](/general-information.md#authorization), to allow handshake communication and response confirmation.
+
+**Endpoint**: `/geographies/`  
+**Method:** `POST`  
+**Authorization**: required  
+**Payload:** An array of [Geography](#schema) objects  
+
+_Optional endpoint, as required by public agencies; if not implemented, the server should reply with `501 Not Implemented` if possible._
+
+#### Responses
+
+_Possible HTTP Status Codes_: 
+201,
+400,
+401,
+406,
+409,
+500, 
+501
+
+See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schema] for details.
+
+[Top][toc]
+
+#### Error Codes:
+
+| `error`              | `error_description`                            | `error_details`[]               |
+| -------------------- | -----------------------------------------------| ------------------------------- |
+| `bad_param`          | A validation error occurred                    | Array of parameters with errors |
+| `missing_param`      | A required parameter is missing                | Array of missing parameters     |
+| `already_created`    | A geography with `geography_id` is already created   |                                 |
+
+Note that you may only create a new MDS Policy. Retired policies are simply referenced in `prev_policies`. See [Updating or Ending Policies](#updating-or-ending-policies) for details.
 
 [Top][toc]
 

--- a/geography/README.md
+++ b/geography/README.md
@@ -264,7 +264,7 @@ See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schem
 
 Allows agencies to push a newly created policies to geographies, similar to the Agency API. This push method creates the opportunity for near real-time communication of geography changes.
 
-Note that once an update is communicated via a policy push, the agency should pull from the relevant [Geography API](../geography) endpoint to see if there are new or changed geographic areas. 
+Note that when an update is communicated via a geography push, the agency should pull or push from the relevant [Policy API](../policy) endpoint to see if there are new or changed policies related to this geographic area. 
 
 Endpoint producers **SHALL** provide authorization for API endpoints via a bearer token based auth system specified in the MDS [Authorization section](/general-information.md#authorization), to allow handshake communication and response confirmation.
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -19,8 +19,8 @@ This specification describes the digital relationship between _mobility as a ser
 - [REST Endpoints](#rest-endpoints)
   - [Responses and Error Messages](#responses-and-error-messages)
   - [Policies](#policies)
-    - [Policies - Get](policies---get)
-    - [Policies - Create](policies---create)
+    - [Policies - Get](#policies---get)
+    - [Policies - Create](#policies---create)
   - [Geographies](#geographies)
   - [Requirements](#requirements)
 - [Flat Files](#flat-files)
@@ -151,6 +151,8 @@ See the [Responses section][responses] for information on valid MDS response cod
 
 #### Policies - Get
 
+Allows operators to pull a list of active policies from agencies. 
+
 **Endpoint**: `/policies/{policy_id}`  
 **Method**: `GET`  
 **Schema:** See [`mds-openapi`](https://github.com/openmobilityfoundation/mds-openapi) repository for schema.    
@@ -194,7 +196,7 @@ See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schem
 
 #### Policies - Create
 
-
+Allows agencies to push a newly created policies from agencies. 
 
 **Responses**
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -151,7 +151,7 @@ See the [Responses section][responses] for information on valid MDS response cod
 
 #### Policies - Get
 
-Allows operators to pull a list of active policies from agencies. 
+Allows operators to pull a list of active policies from agencies, similar to the Provider API. 
 
 **Endpoint**: `/policies/{policy_id}`  
 **Method**: `GET`  
@@ -196,11 +196,35 @@ See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schem
 
 #### Policies - Create
 
-Allows agencies to push a newly created policies from agencies. 
+Allows agencies to push a newly created policies from agencies, similar to the Agency API. This push method creates the opportunity for near real-time communication of policy changes. Endpoint producers **SHALL** provide authorization for API endpoints via a bearer token based auth system specified in the MDS [Authorization section](/general-information.md#authorization), to allow handshake communication and response confirmation.
+
+**Endpoint**: `/policies/`  
+**Method:** `POST`  
+**Payload:** An array of [Policy](#policy) objects  
 
 **Responses**
 
+_Possible HTTP Status Codes_: 
+201,
+400,
+401,
+406,
+409,
+500
 
+See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schema] for details.
+
+[Top][toc]
+
+#### Error Codes:
+
+| `error`              | `error_description`                            | `error_details`[]               |
+| -------------------- | -----------------------------------------------| ------------------------------- |
+| `bad_param`          | A validation error occurred                    | Array of parameters with errors |
+| `missing_param`      | A required parameter is missing                | Array of missing parameters     |
+| `already_created`    | A policy with `policy_id` is already created   |                                 |
+
+Note that you may only create a new MDS Policy. Retired policies are simply referenced in `prev_policies`. See [Updating or Ending Policies](#updating-or-ending-policies) for details.
 
 [Top][toc]
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -19,6 +19,8 @@ This specification describes the digital relationship between _mobility as a ser
 - [REST Endpoints](#rest-endpoints)
   - [Responses and Error Messages](#responses-and-error-messages)
   - [Policies](#policies)
+    - [Policies - Get](policies---get)
+    - [Policies - Create](policies---create)
   - [Geographies](#geographies)
   - [Requirements](#requirements)
 - [Flat Files](#flat-files)
@@ -147,6 +149,8 @@ See the [Responses section][responses] for information on valid MDS response cod
 
 ### Policies
 
+#### Policies - Get
+
 **Endpoint**: `/policies/{policy_id}`  
 **Method**: `GET`  
 **Schema:** See [`mds-openapi`](https://github.com/openmobilityfoundation/mds-openapi) repository for schema.    
@@ -175,7 +179,7 @@ Policies will be returned in order of effective date (see schema below), with pa
 
 `provider_id` is an implicit parameter and will be encoded in the authentication mechanism, or a complete list of policies should be produced. If the Agency decides that Provider-specific policy documents should not be shared with other Providers (e.g. punitive policy in response to violations), an Agency should filter policy objects before serving them via this endpoint.
 
-### Responses
+**Responses**
 
 _Possible HTTP Status Codes_: 
 200,
@@ -185,6 +189,16 @@ _Possible HTTP Status Codes_:
 500
 
 See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schema] for details.
+
+[Top][toc]
+
+#### Policies - Create
+
+
+
+**Responses**
+
+
 
 [Top][toc]
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -198,6 +198,8 @@ See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schem
 
 Allows agencies to push a newly created policies to operators, similar to the Agency API. This push method creates the opportunity for near real-time communication of policy changes.
 
+Note that once an update is communicated via a policy push, the agency should pull from the relevant [Geography API](../geography) endpoint to see if there are new or changed geographic areas. 
+
 Endpoint producers **SHALL** provide authorization for API endpoints via a bearer token based auth system specified in the MDS [Authorization section](/general-information.md#authorization), to allow handshake communication and response confirmation.
 
 **Endpoint**: `/policies/`  

--- a/policy/README.md
+++ b/policy/README.md
@@ -196,7 +196,9 @@ See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schem
 
 #### Policies - Create
 
-Allows agencies to push a newly created policies from agencies, similar to the Agency API. This push method creates the opportunity for near real-time communication of policy changes. Endpoint producers **SHALL** provide authorization for API endpoints via a bearer token based auth system specified in the MDS [Authorization section](/general-information.md#authorization), to allow handshake communication and response confirmation.
+Allows agencies to push a newly created policies to operators, similar to the Agency API. This push method creates the opportunity for near real-time communication of policy changes.
+
+Endpoint producers **SHALL** provide authorization for API endpoints via a bearer token based auth system specified in the MDS [Authorization section](/general-information.md#authorization), to allow handshake communication and response confirmation.
 
 **Endpoint**: `/policies/`  
 **Method:** `POST`  

--- a/policy/README.md
+++ b/policy/README.md
@@ -202,7 +202,10 @@ Endpoint producers **SHALL** provide authorization for API endpoints via a beare
 
 **Endpoint**: `/policies/`  
 **Method:** `POST`  
+**Authorization**: required  
 **Payload:** An array of [Policy](#policy) objects  
+
+_Optional endpoint, as required by public agencies; if not implemented, the server should reply with `501 Not Implemented`._
 
 **Responses**
 
@@ -212,7 +215,8 @@ _Possible HTTP Status Codes_:
 401,
 406,
 409,
-500
+500, 
+501
 
 See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schema] for details.
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -198,7 +198,7 @@ See [Responses][responses], [Bulk Responses][bulk-responses], and [schema][schem
 
 Allows agencies to push a newly created policies to operators, similar to the Agency API. This push method creates the opportunity for near real-time communication of policy changes.
 
-Note that once an update is communicated via a policy push, the agency should pull from the relevant [Geography API](../geography) endpoint to see if there are new or changed geographic areas. 
+Note that once an update is communicated via a policy push, the agency should push or pull from the relevant [Geography API](../geography) endpoint to get the latest information on new or changed geographic areas. 
 
 Endpoint producers **SHALL** provide authorization for API endpoints via a bearer token based auth system specified in the MDS [Authorization section](/general-information.md#authorization), to allow handshake communication and response confirmation.
 
@@ -207,7 +207,7 @@ Endpoint producers **SHALL** provide authorization for API endpoints via a beare
 **Authorization**: required  
 **Payload:** An array of [Policy](#policy) objects  
 
-_Optional endpoint, as required by public agencies; if not implemented, the server should reply with `501 Not Implemented`._
+_Optional endpoint, as required by public agencies; if not implemented, the server should reply with `501 Not Implemented` if possible._
 
 **Responses**
 


### PR DESCRIPTION
## Explain pull request

Creating an option for a Policy creation push API, per the discussion at #906, to allow more real time policy updates, less data overhead, less required Policy endpoint checking, and aligning with other parts of MDS (e.g. Agency).

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which spec(s) will this pull request impact?

* `policy`

## Additional context

Similar to recent [Events push in CDS](https://github.com/openmobilityfoundation/curb-data-specification/pull/180).
