### PR TITLE
Clarify relationship between /vehicles and /vehicles/status

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -181,9 +181,12 @@ As with other MDS APIs, the vehicles endpoints are intended for use by regulator
 
 The `/vehicles` endpoint returns the specified vehicle (if a `device_id` is provided) or a list of vehicles.
 It contains vehicle properties that do not change often.
-When `/vehicles` is called without specifying a device ID it should return every vehicle that has
+When `/vehicles` is called without specifying a device ID it must return every vehicle that has
 been deployed in an agency's [Jurisdiction](/general-information.md#definitions) and/or area of agency responsibility
-in the last 30 days.
+in the last 30 days and it must include every vehicle included when calling the `/vehicles/status`
+endpoint at the same time without specifying a specific vehicle. (In other words, if someone
+retrieves `/vehicles/status` and `/vehicles` at the same time, they must be able to find every
+vehicle in the `/vehicles/status` response in the `/vehicles` response.)
 Vehicle information about all device IDs present in other MDS endpoints must be acessible via the
 `/vehicles/{device_id}` style call regardless of when they were deployed.
 


### PR DESCRIPTION
## Explain pull request

I'm trying to make it explicit that when calling the /vehicles endpoint without specifying a vehicle it must include all vehicles returned by calling the /vehicles/status at the same time without specifying a vehicle. (It may also include additional vehicles as appropriate, but the response must include all vehicles from /vehicles/status.) I think the existing documentation says this implicitly, but I've encountered some confusion in the wild and would like to make it explicit.

## Is this a breaking change

A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint).

* No, not breaking

## Impacted Spec

Which spec(s) will this pull request impact?

* `provider`

## Additional context

None.
