### PR TITLE
Add Getaround car-share provider to providers.csv

### DIFF
--- a/providers.csv
+++ b/providers.csv
@@ -80,3 +80,4 @@ Code3,passenger-services,b49a32d7-a418-4a6a-9f81-b5227d6c7ef8,https://code3trans
 Track My Shuttle,passenger-services,dd7db795-09c0-402f-9441-360235da3025,https://trackmyshuttle.com/,,
 Greenwheels,car-share,5f88cd9e-2c7e-477a-a531-f68143121876,https://www.greenwheels.nl,,
 Sixt,car-share,df72d104-372f-4d98-a4c3-9b001967990e,https://sixt.com/,https://api.orange.sixt.com/v1/share-third-party-sources/mds,https://api.orange.sixt.com/v1/share-third-party-sources/gbfs
+Getaround,car-share,ede4d096-1641-4077-b986-37c602e881ae,https:getaround.com/,,


### PR DESCRIPTION
---
name: Default
about: Suggest changes to MDS
title: Add Getaround as car-share provider
---

# MDS Pull Request

## Explain pull request

Adding Getaround to the MDS provider registry for car-share services. This adds the required provider information including provider_name, mode_id, provider_id (UUID), and company URL to enable MDS integration for Getaround's car-share operations.

## Is this a breaking change

* No, not breaking

## Impacted Spec

This impacts the provider registry only.

## Additional context

Adding Getaround with the following details:
- Provider Name: Getaround
- Mode: car-share
- Provider ID: ede4d096-1641-4077-b986-37c602e881ae
- URL: https:getaround.com/

The end goal is to use the Agency API to send some data to our partner (Bergen Municipality).

Thanks a lot.