### PR TITLE
Feature custom attributes

### DIFF
--- a/data-types.md
+++ b/data-types.md
@@ -42,6 +42,7 @@ A vehicle record is as follows:
 | `hardware_model`     | String   | Required if Available | Number, identifier, or description of the main device hardware model. Can apply to any mode. |
 | `commissioned`       | [Timestamp][ts] | Conditionally Required | Date/time the vehicle first starts providing service in the jurisdiction. Required if asked for by public agency. |
 | `decommissioned`     | [Timestamp][ts] | Conditionally Required | Date/time the vehicle stops providing service in the jurisdiction and is decommissioned. Required when the vehicle is retired from operations. |
+| `custom_attributes`| [Custom Attributes](/data-types.md#custom-attributes) JSON Object | [Optional](./general-information.md#optional-fields) | Additional attributes (fields and data) to include in this [endpoint](/general-information.md#rest-endpoints). |
 
 [Top][toc]
 
@@ -131,6 +132,7 @@ Events represent changes in vehicle status.
 | `associated_ticket` | String | [Optional](./general-information.md#optional-fields) | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system |
 | `gtfs_stop_id` | String | [Optional](./general-information.md#optional-fields) | A unique stop ID to be recorded when a vehicle makes a stop event at a location. Matches [GTFS](https://gtfs.org/documentation/schedule/reference/) `stop_id` |
 | `external_references` | Array of [External Reference][external-reference] objects | [Optional](./general-information.md#optional-fields) | One or more references impacting or related to this Event. |
+| `custom_attributes`| [Custom Attributes](/data-types.md#custom-attributes) JSON Object | [Optional](./general-information.md#optional-fields) | Additional attributes (fields and data) to include in this [endpoint](/general-information.md#rest-endpoints). |
 
 ### Event Times
 
@@ -266,6 +268,7 @@ A Trip is defined by the following structure:
 | `gtfs_trip_id` | String | Required if Applicable | A unique trip ID for the associated scheduled GTFS route-trip. Matches [GTFS](https://gtfs.org/documentation/schedule/reference/) `trip_id` in the trips.txt and other files.|
 | `gtfs_api_url` | URL | Required if Applicable | Full URL to the location where the associated [GTFS](https://gtfs.org/documentation/schedule/reference/) dataset zip files are located. |
 | `external_references` | Array of [External Reference][external-reference] objects | [Optional](./general-information.md#optional-fields) | One or more references impacting or related to this Trip. |
+| `custom_attributes`| [Custom Attributes](/data-types.md#custom-attributes) JSON Object | [Optional](./general-information.md#optional-fields) | Additional attributes (fields and data) to include in this [endpoint](/general-information.md#rest-endpoints). |
 
 [Top][toc]
 
@@ -291,6 +294,7 @@ A Trip is defined by the following structure:
 | `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds, links, reports, or documents impacting or related to this Incident, as they become available. |
 | `contact_info`     | String          | Optional          | Description of any relevant contact information about the incident the operator can provide. |
 | `preliminary`      | Boolean         | Optional          | If `true`, then this information in this Incident is only preliminary, with more details and/or validation coming at a later date. If `false`, the information provided here is deemed valed with no more updates expected. |
+| `custom_attributes`| [Custom Attributes](/data-types.md#custom-attributes) JSON Object | [Optional](./general-information.md#optional-fields) | Additional attributes (fields and data) to include in this [endpoint](/general-information.md#rest-endpoints). |
 
 [Top][toc]
 

--- a/data-types.md
+++ b/data-types.md
@@ -20,6 +20,7 @@ This MDS data types page catalogs the objects (fields, types, requirements, desc
 - [Enforcement](#enforcement)
   - [Violations](#violations)
 - [External Reference](#external-reference)
+- [Custom Attributes](#custom-attributes)
  
 ## Vehicles
 
@@ -392,6 +393,16 @@ An `external_reference` is a JSON *array* with the following fields within objec
 | `public` | Boolean | [Optional](./general-information.md#optional-fields) | Is this data source able to be viewed with out any sort of authentication? If `true`, the `reference_url` is public. If `false`, the `reference_url` requires some sort of authentication, authorization, or API key to access. This is an informational field to set access expectations for the data source user, and does not provide any credentials directly unless explicitly contained in the `reference_url`. |
 | `identifier_name` | String | [Optional](./general-information.md#optional-fields) | The name of the data field identifier or object that is referenced by the unique `ids`. E.g. "id", "report_id", "trip_id", "vehicle_id", "RoadEventFeature", etc, if relevant and available in `reference_url`. |
 | `ids` | Array of Strings | [Optional](./general-information.md#optional-fields) | An array of one or more **ids** from the data sources that impacts the use of or relationship to part of MDS, e.g. Trips, Events, Stops, etc. The **ids** and their details are be found in the referenced `reference_url`. |
+
+[Top][toc]
+
+## Custom Attributes
+
+Custom Attributes are optional additional attributes that do not fit in other fields and objects in the specification. They are unique for the organizations created and consuming the endpoint, that may not apply to other jurisdictions. Examples include custom identifiers, information required by ordinance, vendor attributes, supplemental data, etc. 
+
+The format is one or more JSON name/value pairs, and the values must be a string. If a `custom_attributes` field is provided in specification API endpoints, then the relevant [endpoint](general-information.md#rest-endpoints) must contain the `custom_attribute_dictionary` field, which describes details of the custom fields provided.
+
+Before creating any custom attributes, the preference is to use existing fields and data objects first. If the fields and data you provide in custom attributes apply to multiple jurisdictions, vendors, and/or scenarios, please open an issue to include new fields in a future release.
 
 [Top][toc]
 

--- a/data-types.md
+++ b/data-types.md
@@ -40,8 +40,8 @@ A vehicle record is as follows:
 | `fuel_capacity`      | Integer  | Required if Available | Capacity of fuel tank (liquid, solid, gaseous) expressed in liters |
 | `maximum_speed`      | Integer  | Required if Available | Maximum speed (kph) possible with vehicle under normal, flat incline, smooth surface conditions. Applicable if the device has a built-in or intelligent speed limiter/governor. |
 | `hardware_model`     | String   | Required if Available | Number, identifier, or description of the main device hardware model. Can apply to any mode. |
-| `commissioned`       | [Timestamp][ts] | Conditionally Required | Date/time the vehicle first starts providing service in the jurisdiction. Required if asked for by public agency. |
-| `decommissioned`     | [Timestamp][ts] | Conditionally Required | Date/time the vehicle stops providing service in the jurisdiction and is decommissioned. Required when the vehicle is retired from operations. |
+| `commissioned`       | [Timestamp][ts] | [Conditionally Required](./general-information.md#conditionally-required-fields) | Date/time the vehicle first starts providing service in the jurisdiction. Required if asked for by public agency. |
+| `decommissioned`     | [Timestamp][ts] | [Conditionally Required](./general-information.md#conditionally-required-fields) | Date/time the vehicle stops providing service in the jurisdiction and is decommissioned. Required when the vehicle is retired from operations. |
 | `custom_attributes`| [Custom Attributes](/data-types.md#custom-attributes) JSON Object | [Optional](./general-information.md#optional-fields) | Additional attributes (fields and data) to include in this [endpoint](/general-information.md#rest-endpoints). |
 
 [Top][toc]
@@ -161,7 +161,7 @@ A standard point of vehicle telemetry. References to latitude and longitude impl
 | `fuel_percent`    | Integer         | [Required if Applicable](./general-information.md#required-if-applicable-fields)  | Percent fuel in vehicle, expressed between 0 and 100 |
 | `tipped_over`     | Boolean         | Required if Known      | If detectable and known, is the device tipped over or not? Default is 'false'. |
 | `gtfs_stop_id` | String | [Optional](./general-information.md#optional-fields) | A unique stop ID to be recorded when a vehicle makes a stop event at a location. Matches [GTFS](https://gtfs.org/documentation/schedule/reference/) `stop_id` |
-| `incident_ids`    | UUID[]          | Optional               | Array of one or more [Incident](#incidents) IDs that are connected to this telemetry data point. |
+| `incident_ids`    | UUID[]          | [Optional](./general-information.md#optional-fields)               | Array of one or more [Incident](#incidents) IDs that are connected to this telemetry data point. |
 
 ### GPS Data
 
@@ -191,7 +191,7 @@ Stops describe vehicle trip start and end locations in a pre-designated physical
 | -----                    | ----                                                  |-------------------|-------------|
 | `stop_id`                | UUID                                                  | Required | Unique ID for stop |
 | `name`                   | String                                                | Required | Name of stop |
-| `last_updated`          | Timestamp                                             | Required | Date/Time that the stop was last updated |
+| `last_updated`           | Timestamp                                             | Required | Date/Time that the stop was last updated |
 | `location`               | [GPS][gps]                                            | Required | Simple centerpoint location of the Stop. The use of the optional `geography_id` is recommended to provide more detail. |
 | `status`                 | [Stop Status](#stop-status)                           | Required | Object representing the status of the Stop. See [Stop Status](#stop-status). |
 | `capacity`               | {vehicle_type: number}                                | Required | Number of total places per vehicle_type |
@@ -265,8 +265,8 @@ A Trip is defined by the following structure:
 | `standard_cost`          | Integer         | [Optional](./general-information.md#optional-fields) | The cost, in the currency defined in `currency`, to perform that trip in the standard operation of the System (see [Costs & Currencies][costs-and-currencies]) |
 | `actual_cost`            | Integer         | [Optional](./general-information.md#optional-fields) | The actual cost, in the currency defined in `currency`, paid by the customer of the *mobility as a service* provider (see [Costs & Currencies][costs-and-currencies]) |
 | `currency`               | String          | [Optional](./general-information.md#optional-fields), USD cents is implied if null.| An [ISO 4217 Alphabetic Currency Code][iso4217] representing the currency of the payee (see [Costs & Currencies][costs-and-currencies]) |
-| `gtfs_trip_id` | String | Required if Applicable | A unique trip ID for the associated scheduled GTFS route-trip. Matches [GTFS](https://gtfs.org/documentation/schedule/reference/) `trip_id` in the trips.txt and other files.|
-| `gtfs_api_url` | URL | Required if Applicable | Full URL to the location where the associated [GTFS](https://gtfs.org/documentation/schedule/reference/) dataset zip files are located. |
+| `gtfs_trip_id` | String | [Required if Applicable](./general-information.md#required-if-applicable-fields)  | A unique trip ID for the associated scheduled GTFS route-trip. Matches [GTFS](https://gtfs.org/documentation/schedule/reference/) `trip_id` in the trips.txt and other files.|
+| `gtfs_api_url` | URL | [Required if Applicable](./general-information.md#required-if-applicable-fields)  | Full URL to the location where the associated [GTFS](https://gtfs.org/documentation/schedule/reference/) dataset zip files are located. |
 | `external_references` | Array of [External Reference][external-reference] objects | [Optional](./general-information.md#optional-fields) | One or more references impacting or related to this Trip. |
 | `custom_attributes`| [Custom Attributes](/data-types.md#custom-attributes) JSON Object | [Optional](./general-information.md#optional-fields) | Additional attributes (fields and data) to include in this [endpoint](/general-information.md#rest-endpoints). |
 
@@ -284,16 +284,16 @@ A Trip is defined by the following structure:
 | `discovery_time`   | [Timestamp][ts] | Required          | Date/time that incident was first discovered by the operator. This may be at the same moment of the `incident_time`, or may have been discovered later. |
 | `publication_time` | [Timestamp][ts] | Required          | Date/time that incident became first available to an agency through an Incident endpoint. |
 | `last_updated`     | [Timestamp][ts] | Required          | Date/time that incident was last updated in the Incident endpoint. |
-| `description`      | String          | Optional          | Text description of the incident. |
-| `severity`         | String          | Optional          | Text description of the severity of the incident. |
-| `medical_dispatch` | Boolean         | Optional          | If `true`, a medical dispatch occured connected to the incident. |
-| `medical_transport` | Boolean        | Optional          | If `true`, one or more individuals was transported via an ambulance or emergency response vehicle because of the incident. |
-| `report_id`        | String          | Optional          | Identifier of an external report, from a police report, citation, internal system, service request, etc. The report source is communicated by the operator to the agency outside of MDS. |
-| `report_type`      | String          | Optional          | Description of the type of report referenced by the `report_id`, eg. police, customer, remote operator, 311 call, etc. |
-| `enforcement`      | [Enforcement](#enforcement) | Optional | Enforcement and violation information related to this incident. Can be used for any `incident_type`. |
-| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds, links, reports, or documents impacting or related to this Incident, as they become available. |
-| `contact_info`     | String          | Optional          | Description of any relevant contact information about the incident the operator can provide. |
-| `preliminary`      | Boolean         | Optional          | If `true`, then this information in this Incident is only preliminary, with more details and/or validation coming at a later date. If `false`, the information provided here is deemed valed with no more updates expected. |
+| `description`      | String          | [Optional](./general-information.md#optional-fields)          | Text description of the incident. |
+| `severity`         | String          | [Optional](./general-information.md#optional-fields)          | Text description of the severity of the incident. |
+| `medical_dispatch` | Boolean         | [Optional](./general-information.md#optional-fields)          | If `true`, a medical dispatch occured connected to the incident. |
+| `medical_transport` | Boolean        | [Optional](./general-information.md#optional-fields)          | If `true`, one or more individuals was transported via an ambulance or emergency response vehicle because of the incident. |
+| `report_id`        | String          | [Optional](./general-information.md#optional-fields)          | Identifier of an external report, from a police report, citation, internal system, service request, etc. The report source is communicated by the operator to the agency outside of MDS. |
+| `report_type`      | String          | [Optional](./general-information.md#optional-fields)          | Description of the type of report referenced by the `report_id`, eg. police, customer, remote operator, 311 call, etc. |
+| `enforcement`      | [Enforcement](#enforcement) | [Optional](./general-information.md#optional-fields) | Enforcement and violation information related to this incident. Can be used for any `incident_type`. |
+| `external_references` | Array of [External Reference][external-reference] objects | [Optional](./general-information.md#optional-fields) | One or more references to external data feeds, links, reports, or documents impacting or related to this Incident, as they become available. |
+| `contact_info`     | String          | [Optional](./general-information.md#optional-fields)          | Description of any relevant contact information about the incident the operator can provide. |
+| `preliminary`      | Boolean         | [Optional](./general-information.md#optional-fields)          | If `true`, then this information in this Incident is only preliminary, with more details and/or validation coming at a later date. If `false`, the information provided here is deemed valed with no more updates expected. |
 | `custom_attributes`| [Custom Attributes](/data-types.md#custom-attributes) JSON Object | [Optional](./general-information.md#optional-fields) | Additional attributes (fields and data) to include in this [endpoint](/general-information.md#rest-endpoints). |
 
 [Top][toc]
@@ -362,11 +362,11 @@ The `enforcement` object is a JSON *object* with the following fields:
 | Name             | Type    | Required/Optional | Description   |
 | ---------------- | ------- | ----------------- | ------------- |
 | `enforcement_id` | UUID    | Required          | An identifier unique to the enforcement incident, generated the first time an enforcement event is recorded, and referenced in future related enforcement events. Multiple Incidents (ex: `crash`, `violation`, or `vandalism`) that relate to the same enforcement activity can share the same `enforcement_id`. | 
-| `citation_id`    | String  | Optional          | A unique id which represents a single citation. |
-| `is_warning`     | Boolean | Optional          | A boolean value to indicate if the enforcement action is being processed as a warning.  |
-| `action_taken`   | String  | Optional          | Indicates how the violation was enforced. Typical well-known values are `citation_registered`, `citation_posted`, `citation_served`, or `citation_emailed`. |
-| `citation_cost`  | String  | Optional          | The total cost of all violations associated to this enforcement action. |
-| `violations`     | Array of [Violations](#violations) | Optional          | An array of Violation objects that indicate the one-to-many violations associated to this enforcement event. |
+| `citation_id`    | String  | [Optional](./general-information.md#optional-fields)          | A unique id which represents a single citation. |
+| `is_warning`     | Boolean | [Optional](./general-information.md#optional-fields)          | A boolean value to indicate if the enforcement action is being processed as a warning.  |
+| `action_taken`   | String  | [Optional](./general-information.md#optional-fields)          | Indicates how the violation was enforced. Typical well-known values are `citation_registered`, `citation_posted`, `citation_served`, or `citation_emailed`. |
+| `citation_cost`  | String  | [Optional](./general-information.md#optional-fields)          | The total cost of all violations associated to this enforcement action. |
+| `violations`     | Array of [Violations](#violations) | [Optional](./general-information.md#optional-fields)          | An array of Violation objects that indicate the one-to-many violations associated to this enforcement event. |
 
 [Top][toc]
 
@@ -378,9 +378,9 @@ The `violations` object is a JSON *object* with the following fields:
 
 | Name             | Type   | Required/Optional | Description   |
 | ---------------- | ------ | ----------------- | ------------- |
-| `violation_code` | String | Optional          | The unique code created by the municipality, city, county, state, federal, or enforcement agency to identify the type of rule being enforced. |
-| `violation_name` | String | Optional          | The city/municipal, county, state, provincial, or federal code that was violated. |
-| `violation_cost` | String | Optional          | The original cost associated with the violation. |
+| `violation_code` | String | [Optional](./general-information.md#optional-fields)          | The unique code created by the municipality, city, county, state, federal, or enforcement agency to identify the type of rule being enforced. |
+| `violation_name` | String | [Optional](./general-information.md#optional-fields)          | The city/municipal, county, state, provincial, or federal code that was violated. |
+| `violation_cost` | String | [Optional](./general-information.md#optional-fields)          | The original cost associated with the violation. |
 
 [Top][toc]
 

--- a/general-information.md
+++ b/general-information.md
@@ -22,6 +22,7 @@ This document contains specifications that are shared between the various MDS [A
   - [Error Messages](#error-messages)
   - [Bulk Responses](#bulk-responses)
   - [Failure Details](#failure-details)
+- [REST Endpoints](#rest-endpoints)
 - [Strings](#strings)
 - [Timestamps](#timestamps)
 - [Trips](#trips)
@@ -249,6 +250,32 @@ When there is a failure, stop processing the batch request, and return an error 
 | `error`             | Enum                 | Error code                                          |
 | `error_description` | String               | Human readable error description (can be localized) |
 | `error_details`     | String[]             | Array of fields with errors, if applicable          |
+
+[Top][toc]
+
+# REST Endpoints
+
+Dynamic REST endpoints will return a JSON object containing some of the following possible fields:
+
+| Name   | Type   | Required/Optional   | Description   |
+| ------ | ------ | ------------------- | ------------- |
+| `data` | _Endpoint-dependent_ | Required | The requested data objects. |
+| `version` | String | Required | The specification version that the API conforms to (e.g. `2.1.0`). |
+| `last_updated` | [timestamp][ts] | Required | The last time the data in this API was updated. |
+| `ttl` | Integer | Optional | Representing the number of milliseconds before the data in this feed will be updated again (0 if the data should always be refreshed). |
+| `time_zone` | String | Optional | The time zone that applies to parking regulations in this dataset. MUST be a valid [TZ database](https://www.iana.org/time-zones) time zone name (e.g. `"US/Eastern"` or `"Europe/Paris"`). |
+| `currency` | String | Optional | The ISO 4217 3-letter code for the currency in which rates for curb usage are denominated. All costs should be given as integers in the currency's smallest unit. As an example, to represent $1 USD, specify an amount of 100 (for 100 cents). |
+| `author` | String | Optional | The name of the organization that produces and maintains this data. |
+| `license_url` | URL | Optional | The licensing terms under which this data is provided. |
+| `links` | Object | Conditionally Required | Key value pairs for pagination links, where applicable. |
+| `custom_attributes_dictionary` | URL | Conditionally Required | The data dictionary containing information on the fields and values in [Custom Attributes](/data-types.md#custom-attributes). This should include the attribute name, data type, associated CDS element if applicable, and description of what the attribute represents. Required if any Custom Attributes are provided in an endpoint. |
+
+Servers SHOULD set the `Content-Type` header to `application/vnd.mds+json;version=1.0` to support
+versioning in the future.  Clients SHOULD specify an `Accept` header containing 
+`application/vnd.mds+json;version=1.0`. If the server receives a request that contains an `Accept`
+header but does not include this value; it SHOULD respond with a status of `406 Not Acceptable`.
+
+Note: this section lists payload fields used throughout various MDS APIs and endpoints. See each endpoint for specific details of implementation, which may take precedence over the more general information here.
 
 [Top][toc]
 

--- a/general-information.md
+++ b/general-information.md
@@ -261,14 +261,14 @@ Dynamic REST endpoints will return a JSON object containing some of the followin
 | ------ | ------ | ------------------- | ------------- |
 | `data` | _Endpoint-dependent_ | Required | The requested data objects. |
 | `version` | String | Required | The specification version that the API conforms to (e.g. `2.1.0`). |
-| `last_updated` | [timestamp][ts] | Required | The last time the data in this API was updated. |
-| `ttl` | Integer | Optional | Representing the number of milliseconds before the data in this feed will be updated again (0 if the data should always be refreshed). |
-| `time_zone` | String | Optional | The time zone that applies to parking regulations in this dataset. MUST be a valid [TZ database](https://www.iana.org/time-zones) time zone name (e.g. `"US/Eastern"` or `"Europe/Paris"`). |
-| `currency` | String | Optional | The ISO 4217 3-letter code for the currency in which rates for curb usage are denominated. All costs should be given as integers in the currency's smallest unit. As an example, to represent $1 USD, specify an amount of 100 (for 100 cents). |
-| `author` | String | Optional | The name of the organization that produces and maintains this data. |
-| `license_url` | URL | Optional | The licensing terms under which this data is provided. |
-| `links` | Object | Conditionally Required | Key value pairs for pagination links, where applicable. |
-| `custom_attributes_dictionary` | URL | Conditionally Required | The data dictionary containing information on the fields and values in [Custom Attributes](/data-types.md#custom-attributes). This should include the attribute name, data type, associated element if applicable, and description of what the attribute represents. Required if any Custom Attributes are provided in an endpoint. |
+| `last_updated` | [timestamp](#timestamps) | [Optional](./general-information.md#optional-fields) | The last time the data in this API was updated. |
+| `ttl` | Integer | [Optional](./general-information.md#optional-fields) | Representing the number of milliseconds before the data in this feed will be updated again (0 if the data should always be refreshed). |
+| `time_zone` | String | [Optional](./general-information.md#optional-fields) | The time zone that applies to parking regulations in this dataset. MUST be a valid [TZ database](https://www.iana.org/time-zones) time zone name (e.g. `"US/Eastern"` or `"Europe/Paris"`). |
+| `currency` | String | [Optional](./general-information.md#optional-fields) | The ISO 4217 3-letter code for the currency in which rates for curb usage are denominated. All costs should be given as integers in the currency's smallest unit. As an example, to represent $1 USD, specify an amount of 100 (for 100 cents). |
+| `author` | String | [Optional](./general-information.md#optional-fields) | The name of the organization that produces and maintains this data. |
+| `license_url` | URL | [Optional](./general-information.md#optional-fields) | The licensing terms under which this data is provided. |
+| `links` | Object | [Conditionally Required](./general-information.md#conditionally-required-fields) | Key value pairs for pagination links, where applicable. |
+| `custom_attributes_dictionary` | URL | [Conditionally Required](./general-information.md#conditionally-required-fields) | The data dictionary containing information on the fields and values in [Custom Attributes](/data-types.md#custom-attributes). This should include the attribute name, data type, associated element if applicable, and description of what the attribute represents. Required if any Custom Attributes are provided in an endpoint. |
 
 Servers SHOULD set the `Content-Type` header to `application/vnd.mds+json;version=1.0` to support
 versioning in the future.  Clients SHOULD specify an `Accept` header containing 

--- a/general-information.md
+++ b/general-information.md
@@ -268,7 +268,7 @@ Dynamic REST endpoints will return a JSON object containing some of the followin
 | `author` | String | Optional | The name of the organization that produces and maintains this data. |
 | `license_url` | URL | Optional | The licensing terms under which this data is provided. |
 | `links` | Object | Conditionally Required | Key value pairs for pagination links, where applicable. |
-| `custom_attributes_dictionary` | URL | Conditionally Required | The data dictionary containing information on the fields and values in [Custom Attributes](/data-types.md#custom-attributes). This should include the attribute name, data type, associated CDS element if applicable, and description of what the attribute represents. Required if any Custom Attributes are provided in an endpoint. |
+| `custom_attributes_dictionary` | URL | Conditionally Required | The data dictionary containing information on the fields and values in [Custom Attributes](/data-types.md#custom-attributes). This should include the attribute name, data type, associated element if applicable, and description of what the attribute represents. Required if any Custom Attributes are provided in an endpoint. |
 
 Servers SHOULD set the `Content-Type` header to `application/vnd.mds+json;version=1.0` to support
 versioning in the future.  Clients SHOULD specify an `Accept` header containing 

--- a/policy/README.md
+++ b/policy/README.md
@@ -167,17 +167,17 @@ _Path Parameters:_
 
 | Path Parameter | Type      | Required / Optional | Description                                    |
 | ------------ | --------- | --- | ---------------------------------------------- |
-| `policy_id`         | UUID      | Optional    | If provided, returns one policy object with the matching UUID; default is to return all policy objects.                       |
+| `policy_id`         | UUID      | [Optional](./general-information.md#optional-fields)    | If provided, returns one policy object with the matching UUID; default is to return all policy objects.                       |
 
 _Query Parameters:_
 
 | Query Parameter | Type      | Required / Optional | Description                                    |
 | ------------ | --------- | --- | ---------------------------------------------- |
-| `policy_id`         | UUID      | Optional    | If provided, returns one policy object with the matching UUID; default is to return all policy objects.                       |
-| `start_date` | [timestamp][ts] | Optional    | Beginning date of the queried time range; the default value is the request time |
-| `end_date`   | [timestamp][ts] | Optional    | Ending date of the queried time range; the default value is null, which captures all policies that are effective in the future|
-| `last_updated`   | Boolean | Optional    | If true, the endpoint only returns two fields: `version`, `last_updated`. Useful to quickly check when any data in the file has last been changed, without downloading the entire Policy payload. See the [Schema](#schema) section for an example. If not provided, value is false. |
-| `active_only`   | Boolean | Optional    | If true, return only the current active and future policies, not the retired/previous policies. Any policy that is a prev_policies would not be returned. However, the array of prev_policies still will be returned for reference as part of any relevant active policy. Useful to reduce the Policy payload size for use cases where you do not need to know the previous policy details. If not provided, value is false. |
+| `policy_id`         | UUID      | [Optional](./general-information.md#optional-fields)    | If provided, returns one policy object with the matching UUID; default is to return all policy objects.                       |
+| `start_date` | [timestamp][ts] | [Optional](./general-information.md#optional-fields)    | Beginning date of the queried time range; the default value is the request time |
+| `end_date`   | [timestamp][ts] | [Optional](./general-information.md#optional-fields)    | Ending date of the queried time range; the default value is null, which captures all policies that are effective in the future|
+| `last_updated`   | Boolean | [Optional](./general-information.md#optional-fields)    | If true, the endpoint only returns two fields: `version`, `last_updated`. Useful to quickly check when any data in the file has last been changed, without downloading the entire Policy payload. See the [Schema](#schema) section for an example. If not provided, value is false. |
+| `active_only`   | Boolean | [Optional](./general-information.md#optional-fields)    | If true, return only the current active and future policies, not the retired/previous policies. Any policy that is a prev_policies would not be returned. However, the array of prev_policies still will be returned for reference as part of any relevant active policy. Useful to reduce the Policy payload size for use cases where you do not need to know the previous policy details. If not provided, value is false. |
 
 `start_date` and `end_date` are only considered when no `id` parameter is provided. They should return any policy whose effectiveness overlaps with or is contained with this range. Suppose there's a policy with a `start_date` of 1/1/21 and `end_date` of 1/31/21. Assuming an `end_date` that is null, 12/1/20 and 1/5/21 `start_dates` will return the policy, but 2/10/21 wouldn't. Assuming a `start_date` parameter of say, 11/1/20, then an `end_date` of 12/1/20 wouldn't return the policy, but 1/5/21 and 2/10/21 would. Lastly, a `start_date` of 1/5/21 and `end_date` of 1/6/21 would also return the policy. Please note also that while dates in the format MM:DD:YY are being used here, `start_date` and `end_date` must be numbers representing milliseconds since the Unix epoch time.
 


### PR DESCRIPTION
## Explain pull request

Adding custom attributes to some endpoints, to provide flexibility for new fields, before potentially adopting in a future version. 

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which spec(s) will this pull request impact?

* `agency`
* `policy`

## Additional context

Implemented in parity with CDS. See it in action in [CDS 1.1 release](https://github.com/openmobilityfoundation/curb-data-specification/blob/main/data-types.md#custom-attributes), and the CDS [Issue](https://github.com/openmobilityfoundation/curb-data-specification/issues/150) and [PR](https://github.com/openmobilityfoundation/curb-data-specification/pull/193).

To allow this work the same way, added a REST Endpoint section for MDS [similar to CDS](https://github.com/openmobilityfoundation/curb-data-specification/blob/main/general-information.md#rest-endpoints).
